### PR TITLE
Fix SYCL Header

### DIFF
--- a/examples/cute/tutorial/sgemm_nt_1_sycl.cpp
+++ b/examples/cute/tutorial/sgemm_nt_1_sycl.cpp
@@ -2,7 +2,7 @@
 #include <thrust/host_vector.h>
 #include <thrust/device_vector.h>
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <cute/tensor.hpp>
 #include <syclcompat.hpp>
 


### PR DESCRIPTION
Small PR to change the `sycl` header, from `CL/sycl.hpp` to `sycl/sycl.hpp`
