### PR TITLE
Define CUdeviceptr type for SYCL

### DIFF
--- a/include/cutlass/gpu_generics.h
+++ b/include/cutlass/gpu_generics.h
@@ -357,6 +357,7 @@ namespace cutlass {
     }
 
     using CUresult = unsigned int;
+    using CUdeviceptr = unsigned int*;
     constexpr CUresult CUDA_SUCCESS = 0;
 
     CUTLASS_HOST_DEVICE


### PR DESCRIPTION
This PR fixes the `unknown type name 'CUdeviceptr' error` due to the missing type. More information on this type can be found here: https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TYPES.html#group__CUDA__TYPES_1g183f7b0d8ad008ea2a5fd552537ace4e