### PR TITLE
Add sycl equivalent to cuda events for profiling

### DIFF
--- a/examples/14_ampere_tf32_tensorop_gemm/ampere_tf32_tensorop_gemm_cute.cpp
+++ b/examples/14_ampere_tf32_tensorop_gemm/ampere_tf32_tensorop_gemm_cute.cpp
@@ -29,6 +29,8 @@
  *
  **************************************************************************************************/
 
+#define CUTLASS_SYCLCOMPAT_PROFILING_ENABLED
+
 #include <cstdlib>
 #include <cstdio>
 
@@ -121,6 +123,13 @@ run(Gemm_Op gemm_op)
 
 void test_gemm(int m, int n, int k)
 {
+  sycl::property_list prop = {
+          sycl::property::queue::in_order(),
+          sycl::property::queue::enable_profiling()
+  };
+
+  auto q = sycl::queue(syclcompat::get_default_context(), syclcompat::get_current_device(), prop);
+  syclcompat::set_default_queue(q);
 
   std::cout << "M = " << m << std::endl;
   std::cout << "N = " << n << std::endl;

--- a/examples/cute/tutorial/sgemm_1_sycl.cpp
+++ b/examples/cute/tutorial/sgemm_1_sycl.cpp
@@ -29,6 +29,8 @@
  *
  **************************************************************************************************/
 
+#define CUTLASS_SYCLCOMPAT_PROFILING_ENABLED
+
 #include "cutlass/util/GPU_Clock.hpp"
 #include "cutlass/util/print_error.hpp"
 
@@ -295,12 +297,13 @@ void gemm_nt(int m, int n, int k, Alpha alpha, TA const* A, int ldA, TB const* B
   auto dimBlock = syclcompat::dim3(size(tC));
   auto dimGrid = syclcompat::dim3(size(ceil_div(M, bM)), size(ceil_div(N, bN)));
 
-  syclcompat::launch<
+  auto event = syclcompat::launch<
       gemm_device<decltype(prob_shape), decltype(cta_tiler), TA, decltype(dA), decltype(sA),
                   decltype(tA), TB, decltype(dB), decltype(sB), decltype(tB), TC, decltype(dC),
                   decltype(sC), decltype(tC), Alpha, Beta>>(dimGrid, dimBlock, prob_shape,
                                                             cta_tiler, A, dA, sA, tA, B, dB, sB, tB,
                                                             C, dC, sC, tC, alpha, beta);
+  EventManager::getInstance().addEvent(event);
 }
 
 // Setup params for a TN GEMM
@@ -341,12 +344,13 @@ void gemm_tn(int m, int n, int k, Alpha alpha, TA const* A, int ldA, TB const* B
   auto dimBlock = syclcompat::dim3(size(tC));
   auto dimGrid = syclcompat::dim3(size(ceil_div(M, bM)), size(ceil_div(N, bN)));
 
-  syclcompat::launch<
+  auto event = syclcompat::launch<
       gemm_device<decltype(prob_shape), decltype(cta_tiler), TA, decltype(dA), decltype(sA),
                   decltype(tA), TB, decltype(dB), decltype(sB), decltype(tB), TC, decltype(dC),
                   decltype(sC), decltype(tC), Alpha, Beta>>(dimGrid, dimBlock, prob_shape,
                                                             cta_tiler, A, dA, sA, tA, B, dB, sB, tB,
                                                             C, dC, sC, tC, alpha, beta);
+  EventManager::getInstance().addEvent(event);
 }
 
 template <class TA, class TB, class TC, class Alpha, class Beta>
@@ -375,6 +379,14 @@ int main(int argc, char** argv) {
 
   char transB = 'T';
   if (argc >= 6) sscanf(argv[5], "%c", &transB);
+
+  sycl::property_list prop = {
+          sycl::property::queue::in_order(),
+          sycl::property::queue::enable_profiling()
+  };
+
+  auto q = sycl::queue(syclcompat::get_default_context(), syclcompat::get_current_device(), prop);
+  syclcompat::set_default_queue(q);
 
   using TA = float;
   using TB = float;

--- a/examples/cute/tutorial/sgemm_sm70_sycl.cpp
+++ b/examples/cute/tutorial/sgemm_sm70_sycl.cpp
@@ -29,6 +29,8 @@
  *
  **************************************************************************************************/
 
+#define CUTLASS_SYCLCOMPAT_PROFILING_ENABLED
+
 #include "cutlass/util/GPU_Clock.hpp"
 #include "cutlass/util/print_error.hpp"
 
@@ -283,12 +285,13 @@ void gemm_nt(int m, int n, int k, Alpha alpha, TA const* A, int ldA, TB const* B
 
   auto dimBlock = syclcompat::dim3(size(mmaC));
   auto dimGrid = syclcompat::dim3(size(ceil_div(M, bM)), size(ceil_div(N, bN)));
-  syclcompat::launch<
+  auto event = syclcompat::launch<
       gemm_device<decltype(prob_shape), decltype(cta_tiler), TA, decltype(dA), decltype(sA),
                   decltype(copyA), TB, decltype(dB), decltype(sB), decltype(copyB), TC,
                   decltype(dC), decltype(sC), decltype(mmaC), Alpha, Beta>>(
       dimGrid, dimBlock, prob_shape, cta_tiler, A, dA, sA, copyA, B, dB, sB, copyB, C, dC,
       sC, mmaC, alpha, beta);
+  EventManager::getInstance().addEvent(event);
 }
 
 // Setup params for a TN GEMM
@@ -349,12 +352,13 @@ void gemm_tn(int m, int n, int k, Alpha alpha, TA const* A, int ldA, TB const* B
 
   auto dimBlock = syclcompat::dim3(size(mmaC));
   auto dimGrid = syclcompat::dim3(size(ceil_div(M, bM)), size(ceil_div(N, bN)));
-  syclcompat::launch<
+  auto event = syclcompat::launch<
       gemm_device<decltype(prob_shape), decltype(cta_tiler), TA, decltype(dA), decltype(sA),
                   decltype(copyA), TB, decltype(dB), decltype(sB), decltype(copyB), TC,
                   decltype(dC), decltype(sC), decltype(mmaC), Alpha, Beta>>(
       dimGrid, dimBlock, prob_shape, cta_tiler, A, dA, sA, copyA, B, dB, sB, copyB, C, dC,
       sC, mmaC, alpha, beta);
+  EventManager::getInstance().addEvent(event);
 }
 
 template <class TA, class TB, class TC, class Alpha, class Beta>
@@ -384,6 +388,14 @@ int main(int argc, char** argv) {
 
   char transB = 'T';
   if (argc >= 6) sscanf(argv[5], "%c", &transB);
+
+  sycl::property_list prop = {
+          sycl::property::queue::in_order(),
+          sycl::property::queue::enable_profiling()
+  };
+
+  auto q = sycl::queue(syclcompat::get_default_context(), syclcompat::get_current_device(), prop);
+  syclcompat::set_default_queue(q);
 
   using TA = float;
   using TB = float;

--- a/examples/cute/tutorial/sgemm_sm80_sycl.cpp
+++ b/examples/cute/tutorial/sgemm_sm80_sycl.cpp
@@ -29,6 +29,8 @@
  *
  **************************************************************************************************/
 
+#define CUTLASS_SYCLCOMPAT_PROFILING_ENABLED
+
 #include "cutlass/util/GPU_Clock.hpp"
 #include "cutlass/util/print_error.hpp"
 
@@ -362,12 +364,13 @@ void gemm_nt(int m, int n, int k, Alpha alpha, TA const* A, int ldA, TB const* B
 
   auto dimBlock = syclcompat::dim3(size(mmaC));
   auto dimGrid = syclcompat::dim3(size(ceil_div(M, bM)), size(ceil_div(N, bN)));
-  syclcompat::launch<
+  auto event = syclcompat::launch<
       gemm_device<decltype(prob_shape), decltype(cta_tiler), TA, decltype(dA), decltype(sA),
                   decltype(copyA), TB, decltype(dB), decltype(sB), decltype(copyB), TC,
                   decltype(dC), decltype(sC), decltype(mmaC), Alpha, Beta>>(
       dimGrid, dimBlock, prob_shape, cta_tiler, A, dA, sA, copyA, B, dB, sB, copyB, C, dC, sC, mmaC,
       alpha, beta);
+  EventManager::getInstance().addEvent(event);
 }
 
 // Setup params for a NT GEMM
@@ -433,12 +436,13 @@ void gemm_tn(int m, int n, int k, Alpha alpha, TA const* A, int ldA, TB const* B
 
   auto dimBlock = syclcompat::dim3(size(mmaC));
   auto dimGrid = syclcompat::dim3(size(ceil_div(M, bM)), size(ceil_div(N, bN)));
-  syclcompat::launch<
+  auto event = syclcompat::launch<
       gemm_device<decltype(prob_shape), decltype(cta_tiler), TA, decltype(dA), decltype(sA),
                   decltype(copyA), TB, decltype(dB), decltype(sB), decltype(copyB), TC,
                   decltype(dC), decltype(sC), decltype(mmaC), Alpha, Beta>>(
       dimGrid, dimBlock, prob_shape, cta_tiler, A, dA, sA, copyA, B, dB, sB, copyB, C, dC, sC, mmaC,
       alpha, beta);
+  EventManager::getInstance().addEvent(event);
 }
 
 template <class TA, class TB, class TC, class Alpha, class Beta>
@@ -467,6 +471,14 @@ int main(int argc, char** argv) {
 
   char transB = 'T';
   if (argc >= 6) sscanf(argv[5], "%c", &transB);
+
+  sycl::property_list prop = {
+          sycl::property::queue::in_order(),
+          sycl::property::queue::enable_profiling()
+  };
+
+  auto q = sycl::queue(syclcompat::get_default_context(), syclcompat::get_current_device(), prop);
+  syclcompat::set_default_queue(q);
 
   using TA = float;
   using TB = float;

--- a/examples/sycl/pvc/pvc_bfloat_dpas_gemm_cute.cpp
+++ b/examples/sycl/pvc/pvc_bfloat_dpas_gemm_cute.cpp
@@ -29,6 +29,8 @@
  *
  **************************************************************************************************/
 
+#define CUTLASS_SYCLCOMPAT_PROFILING_ENABLED
+
 #include "cutlass/gemm/device/gemm.h"
 #include "cutlass/epilogue/collective/default_epilogue.hpp"
 #include "cutlass/epilogue/collective/intel_pvc_epilogue.hpp"
@@ -259,6 +261,14 @@ struct ExampleRunner {
     ProblemShapeType problem_size = ProblemShapeType{options.m, options.n, options.k, options.l};
 
     initialize(problem_size);
+
+    sycl::property_list prop = {
+      sycl::property::queue::in_order(),
+      sycl::property::queue::enable_profiling()
+    };
+
+    auto q = sycl::queue(syclcompat::get_default_context(), syclcompat::get_current_device(), prop);
+    syclcompat::set_default_queue(q);
 
     typename Gemm::GemmKernel::Arguments arguments{
       cutlass::gemm::GemmUniversalMode::kGemm,

--- a/include/cutlass/gemm/device/gemm_universal_adapter.h
+++ b/include/cutlass/gemm/device/gemm_universal_adapter.h
@@ -58,6 +58,10 @@
 // 3.x
 #include "cutlass/gemm/kernel/gemm_universal.hpp"
 
+#if defined(CUTLASS_ENABLE_SYCL)
+#include "cutlass/util/sycl_event_manager.hpp"
+#endif
+
 ////////////////////////////////////////////////////////////////////////////////
 
 namespace cutlass::gemm::device {
@@ -407,10 +411,11 @@ public:
         const auto sycl_grid = syclcompat::dim3(grid.x, grid.y, grid.z);
 
 #if defined (SYCL_INTEL_TARGET)
-        syclcompat::experimental::launch<device_kernel<GemmKernel>, DispatchPolicy::SubgroupSize>(sycl_grid, sycl_block, smem_size, params);
+        auto event = syclcompat::experimental::launch<device_kernel<GemmKernel>, DispatchPolicy::SubgroupSize>(sycl_grid, sycl_block, smem_size, params);
 #else
-        syclcompat::launch<device_kernel<GemmKernel>>(sycl_grid, sycl_block, smem_size, params);
+        auto event = syclcompat::launch<device_kernel<GemmKernel>>(sycl_grid, sycl_block, smem_size, params);
 #endif
+        EventManager::getInstance().addEvent(event);
 #else
         device_kernel<GemmKernel><<<grid, block, smem_size, stream>>>(params);
 #endif

--- a/tools/util/include/cutlass/util/sycl_event_manager.hpp
+++ b/tools/util/include/cutlass/util/sycl_event_manager.hpp
@@ -1,0 +1,135 @@
+/***************************************************************************************************
+ * Copyright (c) 2024 - 2024 Codeplay Software Ltd. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+#pragma once
+
+#include <vector>
+#include <sycl/sycl.hpp>
+
+class SyclEvent {
+private:
+    int index;
+
+public:
+    SyclEvent() : index(-1) {
+    };
+
+    int getIndex() const {
+      return index;
+    }
+
+    SyclEvent& operator=(int const& value) {
+      index = value;
+      return *this;
+    };
+};
+
+class EventManager {
+public:
+    static EventManager& getInstance()
+    {
+      static EventManager instance;
+      return instance;
+    }
+private:
+    EventManager() {}
+    std::vector<sycl::event> events{};
+    int recorders = 0;
+
+public:
+    EventManager(EventManager const&) = delete;
+    void operator=(EventManager const&) = delete;
+
+    void startRecording(SyclEvent &event) {
+      if (event.getIndex() != -1) {
+        throw std::runtime_error("Event is already being recorded.");
+      }
+      recorders++;
+      event = static_cast<int>(events.size());
+    }
+
+    void addEvent(const sycl::event &event) {
+      events.push_back(event);
+    }
+
+    void eventDestroy() {
+      recorders--;
+      if (!recorders) {
+        events.clear();
+      }
+    }
+
+    float getEventElapsedTimeMs(SyclEvent const& begin, SyclEvent const& end) {
+      if (begin.getIndex() < 0 || begin.getIndex() > end.getIndex() || end.getIndex() > events.size()) {
+        throw std::runtime_error("Index out of bounds");
+      }
+
+      auto time_event = 0.0;
+      for (int i = begin.getIndex(); i < end.getIndex(); ++i) {
+        auto start_time = events[i].template get_profiling_info<
+                sycl::info::event_profiling::command_start>();
+
+        auto end_time = events[i].template get_profiling_info<
+                sycl::info::event_profiling::command_end>();
+
+        time_event += static_cast<float>(end_time - start_time);
+      }
+      return time_event * 1e-6;
+    }
+
+    void wait(SyclEvent const& begin, SyclEvent const& end) {
+      if (begin.getIndex() < 0 || begin.getIndex() > end.getIndex() || end.getIndex() > events.size()) {
+        throw std::runtime_error("Index out of bounds");
+      }
+
+      for (int i = begin.getIndex(); i < end.getIndex(); ++i) {
+        events[i].wait();
+      }
+    }
+
+};
+
+inline void syclEventDestroy(SyclEvent const& event) {
+  EventManager::getInstance().eventDestroy();
+}
+
+inline void syclEventRecord(SyclEvent &event) {
+  EventManager::getInstance().startRecording(event);
+}
+
+inline void syclEventSynchronize(SyclEvent const& begin, SyclEvent const& end) {
+  EventManager::getInstance().wait(begin, end);
+}
+
+inline void syclEventElapsedTime(float* time, SyclEvent const& begin, SyclEvent const& end) {
+#if defined(CUTLASS_SYCLCOMPAT_PROFILING_ENABLED)
+  *time = EventManager::getInstance().getEventElapsedTimeMs(begin, end);
+#endif
+}


### PR DESCRIPTION
This PR adds an event manager to store the events created when launching a kernel with syclcompat. The functionality is similar to the way cuda events works. 