### PR TITLE
Enable CodeQL code scans 

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,85 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "sycl-develop" ]
+  pull_request:
+    branches: [ "sycl-develop" ]
+  schedule:
+    - cron: '23 5 * * 5'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      # required for all workflows
+      security-events: write
+      # required to fetch internal or private CodeQL packs
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: c-cpp
+          build-mode: manual
+        - language: python
+          build-mode: none
+
+    container:
+      image: nvidia/cuda:12.4.1-devel-ubuntu22.04
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+
+    - name: Install dependencies
+      if: matrix.build-mode == 'none'
+      shell: bash
+      run: |
+        apt update && apt install -y python3
+
+    # For a specific DPC++ nightly build define the repository variable DPCPP_VERSION
+    # for example using the tag: 'nightly-2024-04-22'
+    - name: Build
+      if: matrix.build-mode == 'manual'
+      shell: bash
+      run: |
+        apt update && apt install -y cmake curl git jq libstdc++-12-dev ninja-build python3 wget && \
+        pushd /usr/local && \
+        echo "Will use DPCPP $DPCPP_VERSION."
+        if [[ "$DPCPP_VERSION" != "" ]]; then \
+          echo "Downloading DPCPP from https://github.com/intel/llvm/releases/download/$DPCPP_VERSION/sycl_linux.tar.gz"; \
+          wget -q https://github.com/intel/llvm/releases/download/$DPCPP_VERSION/sycl_linux.tar.gz; \
+        else
+          latest=$(curl -sS https://api.github.com/repos/intel/llvm/releases | jq -r '[.[].tag_name|select(match("nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}"))][0]') && \
+          echo "Downloading DPCPP from https://github.com/intel/llvm/releases/download/${latest}/sycl_linux.tar.gz"; \
+          wget -q https://github.com/intel/llvm/releases/download/${latest}/sycl_linux.tar.gz; \
+        fi && \
+        tar -xf sycl_linux.tar.gz && \
+        export PATH=/usr/local/bin/:$PATH && \
+        export C_INCLUDE_PATH=/usr/local/include/:$C_INCLUDE_PATH && \
+        export LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH && \
+        export CC=clang && \
+        export CXX=clang++ && \
+        popd && \
+        clang++ --version && \
+        cmake -G Ninja  \
+          -DCMAKE_CUDA_HOST_COMPILER=clang++  \
+          -DCUTLASS_ENABLE_SYCL=ON \
+          -DDPCPP_SYCL_TARGET=nvptx64-nvidia-cuda \
+          -DDPCPP_SYCL_ARCH=sm_80 && \
+        cmake --build .
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
CodeQL will scan code on `sycl-develop` branch and pull requests.

Configuration runs scans for C - C++ code and Python code.

`nvidia/cuda` image is required to build the source code.