### PR TITLE
Fix B matrix layout

### DIFF
--- a/include/cute/atom/copy_traits_xe.hpp
+++ b/include/cute/atom/copy_traits_xe.hpp
@@ -46,7 +46,7 @@ auto get_shape_WHD(cute::Stride<Int<1>, IntT, IntT> , cute::Shape<int,int,int> s
 
 template <class IntT>
 CUTE_HOST_DEVICE constexpr
-auto get_shape_WHD(cute::Stride<IntT, Int<1>, IntT> s, cute::Shape<int,int,int> shape_MKL) {
+auto get_shape_WHD(cute::Stride<IntT, Int<1>, IntT> , cute::Shape<int,int,int> shape_MKL) {
   return Shape<int, int, int>(get<1>(shape_MKL), get<0>(shape_MKL), get<2>(shape_MKL));
 }
 

--- a/include/cute/atom/copy_traits_xe.hpp
+++ b/include/cute/atom/copy_traits_xe.hpp
@@ -40,7 +40,7 @@ namespace cute
 
 template <class IntT>
 CUTE_HOST_DEVICE constexpr
-auto get_shape_WHD(cute::Stride<Int<1>, IntT, IntT> s, cute::Shape<int,int,int> shape_MKL) {
+auto get_shape_WHD(cute::Stride<Int<1>, IntT, IntT> , cute::Shape<int,int,int> shape_MKL) {
   return shape_MKL;
 }
 

--- a/include/cute/atom/copy_traits_xe.hpp
+++ b/include/cute/atom/copy_traits_xe.hpp
@@ -81,9 +81,9 @@ struct XE_2D_LD_Unpack
               Tensor<TD, DLayout> &dst)
   {
     static_assert(is_rmem<TD>::value);
-    auto shape_wdh = get_shape_WHD(traits.tensor.stride(), traits.tensor.shape());
-    int W = size<0>(shape_wdh) * sizeof(typename Copy_Traits::CopyInternalType);
-    int H = size<1>(shape_wdh);
+    auto shape_whd = get_shape_WHD(traits.tensor.stride(), traits.tensor.shape());
+    int W = size<0>(shape_whd) * sizeof(typename Copy_Traits::CopyInternalType);
+    int H = size<1>(shape_whd);
     auto [x, y, z] = get_coordinates(traits.tensor.stride(), src);
     CopyOp::copy(traits.tensor.data() + z, W, H, W, intel::coord_t{x, y}, &*dst.data());
   }

--- a/include/cute/atom/copy_traits_xe.hpp
+++ b/include/cute/atom/copy_traits_xe.hpp
@@ -52,7 +52,7 @@ auto get_shape_WHD(cute::Stride<IntT, Int<1>, IntT> , cute::Shape<int,int,int> s
 
 template <class IntT, class TS, class SLayout>
 CUTE_HOST_DEVICE constexpr
-auto get_coordinates(cute::Stride<Int<1>, IntT, IntT> s,
+auto get_coordinates(cute::Stride<Int<1>, IntT, IntT> ,
                      Tensor<ViewEngine<ArithmeticTupleIterator<TS>>, SLayout> const &src) {
   auto [x, y, z] = src.data().coord_;
   return make_coord(x, y, z);

--- a/include/cute/atom/copy_traits_xe.hpp
+++ b/include/cute/atom/copy_traits_xe.hpp
@@ -60,7 +60,7 @@ auto get_coordinates(cute::Stride<Int<1>, IntT, IntT> ,
 
 template <class IntT, class TS, class SLayout>
 CUTE_HOST_DEVICE constexpr
-auto get_coordinates(cute::Stride<IntT, Int<1>, IntT> s,
+auto get_coordinates(cute::Stride<IntT, Int<1>, IntT> ,
                      Tensor<ViewEngine<ArithmeticTupleIterator<TS>>, SLayout> const &src) {
   auto [x, y, z] = src.data().coord_;
   return make_coord(y, x, z);

--- a/include/cute/atom/copy_traits_xe.hpp
+++ b/include/cute/atom/copy_traits_xe.hpp
@@ -140,7 +140,7 @@ struct Copy_Traits<XE_2D_U16x8x16x4x2_LD_N, GTensor>
   // Map from (src-thr,src-val) to bit
   using SrcLayout = Layout<Shape<_1, Shape<_1, _1>>>; // one coordinate
   // Map from (dst-thr,dst-val) to bit
-  using DstLayout = Layout<Shape<_1, Shape<_32, _2>>>;
+  using DstLayout = Layout<Shape<_1, Shape<_64, _1>>>;
   // Reference map from (thr,val) to bit
   using RefLayout = SrcLayout;
   using CopyInternalType = ushort;

--- a/include/cute/util/debug.hpp
+++ b/include/cute/util/debug.hpp
@@ -129,7 +129,9 @@ bool
 block(int bid)
 {
 #if defined(CUTLASS_ENABLE_SYCL)
-    return (syclcompat::get_nd_item<3>().get_group_linear_id()==bid);
+  using namespace syclcompat;
+  return (work_group_id::x() + work_group_id::y() * work_group_range::x() +
+          work_group_id::z() * work_group_range::y() * work_group_range::x() == bid);
 #elif defined(__CUDA_ARCH__)
   return blockIdx.x + blockIdx.y*gridDim.x + blockIdx.z*gridDim.x*gridDim.y == bid;
 #else
@@ -142,7 +144,9 @@ bool
 thread(int tid, int bid)
 {
 #if defined(CUTLASS_ENABLE_SYCL)
-    return (syclcompat::get_nd_item<3>().get_global_linear_id()==bid);
+  using namespace syclcompat;
+  return (local_id::x() + local_id::y() * local_range::x() +
+          local_id::z() * local_range::x() * local_range::y() == tid) && block(bid);
 #elif defined(__CUDA_ARCH__)
   return (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y == tid) && block(bid);
 #else

--- a/include/cutlass/gemm/collective/intel_pvc_mma.hpp
+++ b/include/cutlass/gemm/collective/intel_pvc_mma.hpp
@@ -149,7 +149,7 @@ struct CollectiveMma<
     auto [M,N,K,L] = problem_shape_MNKL;
 
     Tensor tensorA = make_tensor(args.ptr_A, make_layout(make_shape(M,K,L), args.dA));
-    Tensor tensorB = make_tensor(args.ptr_B, make_layout(make_shape(K,N,L), args.dB));
+    Tensor tensorB = make_tensor(args.ptr_B, make_layout(make_shape(N,K,L), args.dB));
 
     typename Params::XE_Copy_A copyA = make_xe_2d_copy<GmemTiledCopyA>(tensorA);
     typename Params::XE_Copy_B copyB = make_xe_2d_copy<GmemTiledCopyB>(tensorB);
@@ -187,14 +187,14 @@ struct CollectiveMma<
     static_assert(is_rmem<FrgTensorC>::value, "C tensor must be rmem resident.");
 
     // Tensor to hold input data
-    Tensor tAr = make_tensor<typename TiledMma::ValTypeA>(Shape<Int<get<0>(SubgroupTileShape{}) * FragsK>, Int<1>>{});
-    Tensor tBr = make_tensor<typename TiledMma::ValTypeB>(
-            Shape<Int<FragsK * get<1>(SubgroupTileShape{}) / FragsN>, Int<FragsN>>{});
+    Tensor tAr = make_tensor<typename TiledMma::ValTypeA>(Shape<Int<get<0>(SubgroupTileShape{})>, Int<FragsK>>{});
+    Tensor tBr = make_tensor<typename TiledMma::ValTypeB>(Shape<Int<get<1>(SubgroupTileShape{}) / 2>, Int<FragsN>>{});
 
     Tensor tAr_view = make_tensor(static_cast<decltype(tAr) &&>(tAr).data(),
                             Shape<Int<VecA>, Int<FragsM>, Int<FragsK>>{});
     Tensor tBr_view = make_tensor(static_cast<decltype(tBr) &&>(tBr).data(),
-                            Shape<Int<VecB>, Int<FragsK>, Int<FragsN>>{});
+                            Shape<Int<VecB>, Int<FragsN>, Int<FragsK>>{},
+                            Stride<_1, Int<get<1>(SubgroupTileShape{}) / 2>, Int<VecB>>{});
 
     // Instantiate the M MA object
     TiledMma tiled_mma;
@@ -208,9 +208,7 @@ struct CollectiveMma<
      copy(mainloop.gmem_tiled_copy_a, gA(_,_,k), tAr);
      copy(mainloop.gmem_tiled_copy_b, gB(_,k/2,_), tBr);
 
-     for (int kl = 0; kl < FragsK; kl++) {
-       cute::gemm(tiled_mma, accum, tAr_view(_, _, kl), tBr_view(_, kl, _), src_accum);
-     }
+     cute::gemm(tiled_mma, accum, tAr_view, tBr_view, src_accum);
    }
   }
 };

--- a/include/cutlass/gemm/collective/intel_pvc_mma.hpp
+++ b/include/cutlass/gemm/collective/intel_pvc_mma.hpp
@@ -206,7 +206,7 @@ struct CollectiveMma<
    {
      // Copy gmem to rmem for the first k_tile
      copy(mainloop.gmem_tiled_copy_a, gA(_,_,k), tAr);
-     copy(mainloop.gmem_tiled_copy_b, gB(_,k/2,_), tBr);
+     copy(mainloop.gmem_tiled_copy_b, gB(_,_,k/2), tBr);
 
      cute::gemm(tiled_mma, accum, tAr_view, tBr_view, src_accum);
    }

--- a/include/cutlass/gemm/collective/intel_pvc_mma.hpp
+++ b/include/cutlass/gemm/collective/intel_pvc_mma.hpp
@@ -187,7 +187,7 @@ struct CollectiveMma<
     static_assert(is_rmem<FrgTensorC>::value, "C tensor must be rmem resident.");
 
     // Tensor to hold input data
-    Tensor tAr = make_tensor<typename TiledMma::ValTypeA>(Shape<Int<get<0>(SubgroupTileShape{})>, Int<FragsK>>{});
+    Tensor tAr = make_tensor<typename TiledMma::ValTypeA>(Shape<Int<get<0>(SubgroupTileShape{}) * FragsK>, _1>{});
     Tensor tBr = make_tensor<typename TiledMma::ValTypeB>(Shape<Int<get<1>(SubgroupTileShape{}) / 2>, Int<FragsN>>{});
 
     Tensor tAr_view = make_tensor(static_cast<decltype(tAr) &&>(tAr).data(),

--- a/include/cutlass/gemm/kernel/intel_pvc_gemm.hpp
+++ b/include/cutlass/gemm/kernel/intel_pvc_gemm.hpp
@@ -221,9 +221,9 @@ public:
             make_stride(Int<FragsM>{} * get<0>(MmaAtomShape()),_1{}));
 
     Tensor tBi = params.mainloop.gmem_tiled_copy_b.get_pvc_tensor(
-            make_coord(0, n_coord, 0),
-            make_shape(K, Int<FragsN>{}, L),
-            make_stride(_1{}, get<1>(MmaAtomShape())));
+            make_coord(n_coord, 0, 0),
+            make_shape(Int<FragsN>{}, K / 2, L),
+            make_stride(get<1>(MmaAtomShape()), _1{}));
 
     // Compute tile residues for predication
     auto m_max_coord = M - get<0>(subgroup_shape) * m_coord;                             // M - SUB_M * m_coord


### PR DESCRIPTION
This PR fixes an issue where the B matrix was defined as row-major, while Cutlass internally uses M, N, or K major to define matrices.