### PR TITLE
Fix CUTLASS Python documentation build

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -152,6 +152,10 @@ Building the documentation requires additional packages.  The following commands
 ```bash
 sudo apt-get install pandoc
 pip install --upgrade Sphinx furo pandoc myst-parser sphinx-copybutton nbsphinx nbsphinx-link sphinx-inline-tabs
+# Needed for jupyter notebooks
+pip install ipykernel
+# Needed as latest versions are not compatible with Sphinx as of now.
+pip install docutils~=0.20.0
 ```
 
 To build documentation, you must first have installed the CUTLASS Python interface via the

--- a/python/cutlass/epilogue/epilogue.py
+++ b/python/cutlass/epilogue/epilogue.py
@@ -122,8 +122,9 @@ def trace(fn, example_tensors, **kwargs):
     :param example_tensors: example inputs for fn
     :type example_tensors: dict
 
-    .. hightlight:: python
+    .. highlight:: python
     .. code-block:: python
+
         import cutlass.backend.evt
 
         # Define epilogue function as Python callable


### PR DESCRIPTION
Modify problematic docstring and instructions to fix build of CUTLASS Python documentation.

- Docstring: missing newline starting code-block and wrong keyword
- `ipykernel` missing lead to error on Jupyter notebooks
- `docutils>=0.21` drops a member Sphinx is using. Next versions of Sphinx will fix this by dropping the usage.