### PR TITLE
Initial implementation of SYCL support for Cutlass 3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,12 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
-cmake_policy(SET CMP0112 NEW)
+if(CUTLASS_ENABLE_SYCL)
+  cmake_minimum_required(VERSION 3.22 FATAL_ERROR)
+else()
+  cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
+  cmake_policy(SET CMP0112 NEW)
+endif()
 
 if(cutlass_LOADED)
   # If CUTLASS has been previously fetched and loaded, don't do it again.
@@ -59,11 +63,13 @@ project(CUTLASS VERSION ${_CUTLASS_VERSION_MAJOR}.${_CUTLASS_VERSION_MINOR}.${_C
 
 ################################################################################
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/CUDA.cmake)
+if (NOT CUTLASS_ENABLE_SYCL)
+  include(${CMAKE_CURRENT_SOURCE_DIR}/CUDA.cmake)
+endif()
 
-if (CUDA_VERSION VERSION_LESS 11.3)
+if (CUDA_VERSION VERSION_LESS 11.3 AND NOT CUTLASS_ENABLE_SYCL)
   message(WARNING "CUTLASS ${CUTLASS_VERSION} requires CUDA 11.4 or higher, and strongly recommends CUDA 11.8 or higher.")
-elseif (CUDA_VERSION VERSION_LESS 11.4)
+elseif (CUDA_VERSION VERSION_LESS 11.4 AND NOT CUTLASS_ENABLE_SYCL)
   message(WARNING "CUTLASS ${CUTLASS_VERSION} support for CUDA ${CUDA_VERSION} is deprecated, please use CUDA 11.8 or higher.")
 endif()
 
@@ -71,9 +77,38 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_L
   message(FATAL_ERROR "GCC version must be at least 7.3!")
 endif()
 
-if (CUDA_COMPILER MATCHES "[Cc]lang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
+if (CUDA_COMPILER MATCHES "[Cc]lang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0 AND NOT CUTLASS_ENABLE_SYCL)
   message(FATAL_ERROR "Clang 7.0+ required for GPU compilation")
 endif()
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "[Cc]lang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 19.0 AND CUTLASS_ENABLE_SYCL)
+  message(FATAL_ERROR "Clang version must be at least 19.0!")
+endif()
+
+################################################################################
+#
+# Configure SYCL build options
+#
+################################################################################
+
+set(CUTLASS_ENABLE_SYCL OFF CACHE BOOL "Enable SYCL")
+
+if (CUTLASS_ENABLE_SYCL)
+  set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+  if(DPCPP_SYCL_TARGET STREQUAL "nvptx64-nvidia-cuda")
+    set(SYCL_NVIDIA_TARGET ON)
+    add_compile_definitions(SYCL_NVIDIA_TARGET)
+  elseif(DPCPP_SYCL_TARGET STREQUAL "intel_gpu_pvc")
+    set(SYCL_INTEL_TARGET ON)
+    add_compile_definitions(SYCL_INTEL_TARGET)
+  endif()
+
+  add_compile_definitions(CUTLASS_ENABLE_SYCL)
+  find_package(DPCPP)
+  include(${CMAKE_CURRENT_SOURCE_DIR}/SYCL.cmake)
+endif()
+
 find_package(Doxygen QUIET)
 
 ################################################################################
@@ -137,13 +172,13 @@ set(CUTLASS_USE_SYSTEM_GOOGLETEST OFF CACHE BOOL "Use system/external installati
 ################################################################################
 
 set(CUTLASS_NVCC_ARCHS_SUPPORTED "")
-if (CUDA_VERSION VERSION_GREATER_EQUAL 11.4 AND NOT CUDA_COMPILER MATCHES "[Cc]lang")
+if (CUDA_VERSION VERSION_GREATER_EQUAL 11.4 AND NOT CUDA_COMPILER MATCHES "[Cc]lang" AND NOT CUTLASS_ENABLE_SYCL)
   list(APPEND CUTLASS_NVCC_ARCHS_SUPPORTED 70 72 75 80 86 87)
 endif()
-if (CUDA_VERSION VERSION_GREATER_EQUAL 11.8 AND NOT CUDA_COMPILER MATCHES "[Cc]lang")
+if (CUDA_VERSION VERSION_GREATER_EQUAL 11.8 AND NOT CUDA_COMPILER MATCHES "[Cc]lang" AND NOT CUTLASS_ENABLE_SYCL)
   list(APPEND CUTLASS_NVCC_ARCHS_SUPPORTED 89 90)
 endif()
-if (CUDA_VERSION VERSION_GREATER_EQUAL 12.0 AND NOT CUDA_COMPILER MATCHES "[Cc]lang")
+if (CUDA_VERSION VERSION_GREATER_EQUAL 12.0 AND NOT CUDA_COMPILER MATCHES "[Cc]lang" AND NOT CUTLASS_ENABLE_SYCL)
   list(APPEND CUTLASS_NVCC_ARCHS_SUPPORTED 90a)
 endif()
 set(CUTLASS_NVCC_ARCHS ${CUTLASS_NVCC_ARCHS_SUPPORTED} CACHE STRING "The SM architectures requested.")
@@ -156,7 +191,7 @@ if (CUTLASS_NVCC_ARCHS_SUPPORTED)
   if (CUTLASS_NVCC_ARCHS_UNSUPPORTED)
     message(WARNING "Using unsupported or deprecated compute capabilities ${CUTLASS_NVCC_ARCHS_UNSUPPORTED}. Support may be removed in future versions.")
   endif()
-else()
+elseif(NOT CUTLASS_ENABLE_SYCL)
   message(WARNING "No supported compute capabilities for CUDA ${CUDA_VERSION}.")
 endif()
 
@@ -176,7 +211,9 @@ link_directories(${CUDA_TOOLKIT_ROOT_DIR}/lib64)
 #
 ###################################################################################################
 
-message(STATUS "CUDA Compilation Architectures: ${CUTLASS_NVCC_ARCHS_ENABLED}")
+if (NOT CUTLASS_ENABLE_SYCL)
+  message(STATUS "CUDA Compilation Architectures: ${CUTLASS_NVCC_ARCHS_ENABLED}")
+endif()
 
 if (NOT (CMAKE_BUILD_TYPE OR CONFIGURATION_TYPES))
   # By default we want to build in Release mode to ensure that we're getting best performance.
@@ -387,7 +424,7 @@ if (CUDA_COMPILER MATCHES "[Cc]lang")
   if(CUTLASS_CUDA_CLANG_FLAGS)
     message(STATUS "Using CLANG flags: ${CUTLASS_CUDA_CLANG_FLAGS}")
   endif()
-else()
+elseif(NOT CUTLASS_ENABLE_SYCL)
   if(CUTLASS_CUDA_NVCC_FLAGS)
     message(STATUS "Using NVCC flags: ${CUTLASS_CUDA_NVCC_FLAGS}")
   endif()
@@ -685,7 +722,7 @@ if (DOXYGEN_FOUND)
     )
 endif()
 
-if(NOT WIN32)
+if(NOT WIN32 AND NOT CUTLASS_ENABLE_SYCL)
   # Add common library search paths so executables and libraries can load and run
   # without LD_LIBRARY_PATH being set.
   link_libraries(
@@ -928,7 +965,7 @@ endfunction()
 
 if (CUTLASS_ENABLE_TOOLS)
   add_subdirectory(tools)
-  if (CUTLASS_ENABLE_PROFILER)
+  if (CUTLASS_ENABLE_PROFILER AND NOT CUTLASS_ENABLE_SYCL)
     add_dependencies(test_all test_profiler)
   endif()
 endif()

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -73,6 +73,13 @@ Scott Yokim<br />
 Xiuxia Zhang<br />
 Nick Zhao<br />
 
+## SYCL CONTRIBUTORS
+Alejandro Acosta<br />
+Atharva Dubey<br />
+Mehdi Goli<br />
+Ruyman Reyes<br />
+Muhammad Tanvir<br />
+
 ## ACKNOWLEDGEMENTS
 
 Girish Bharambe<br />

--- a/cmake/FindDPCPP.cmake
+++ b/cmake/FindDPCPP.cmake
@@ -1,0 +1,95 @@
+# Copyright (c) 2024 - 2024 Codeplay Software Ltd. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+include_guard()
+
+include(CheckCXXCompilerFlag)
+include(FindPackageHandleStandardArgs)
+
+set(DPCPP_USER_FLAGS "" CACHE STRING "Additional user-specified compiler flags for DPC++")
+
+get_filename_component(DPCPP_BIN_DIR ${CMAKE_CXX_COMPILER} DIRECTORY)
+find_library(DPCPP_LIB_DIR NAMES sycl sycl6 PATHS "${DPCPP_BIN_DIR}/../lib")
+
+add_library(DPCPP::DPCPP INTERFACE IMPORTED)
+
+set(DPCPP_FLAGS "-fsycl;-mllvm;-enable-global-offset=false;")
+if(NOT "${DPCPP_SYCL_TARGET}" STREQUAL "")
+  list(APPEND DPCPP_FLAGS "-fsycl-targets=${DPCPP_SYCL_TARGET};")
+endif()
+list(APPEND DPCPP_FLAGS "${DPCPP_USER_FLAGS};")
+
+if(NOT "${DPCPP_SYCL_ARCH}" STREQUAL "")
+  if("${DPCPP_SYCL_TARGET}" STREQUAL "nvptx64-nvidia-cuda")
+    list(APPEND DPCPP_FLAGS "-Xsycl-target-backend")
+    list(APPEND DPCPP_FLAGS "--cuda-gpu-arch=${DPCPP_SYCL_ARCH}")
+  endif()
+endif()
+
+if(UNIX)
+  set_target_properties(DPCPP::DPCPP PROPERTIES
+    INTERFACE_COMPILE_OPTIONS "${DPCPP_FLAGS}"
+    INTERFACE_LINK_OPTIONS "${DPCPP_FLAGS}"
+    INTERFACE_LINK_LIBRARIES ${DPCPP_LIB_DIR}
+    INTERFACE_INCLUDE_DIRECTORIES "${DPCPP_BIN_DIR}/../include/sycl;${DPCPP_BIN_DIR}/../include")
+  message(STATUS "DPCPP INCLUDE DIR: ${DPCPP_BIN_DIR}/../include/sycl;${DPCPP_BIN_DIR}/../include")
+  message(STATUS "Using DPCPP flags: ${DPCPP_FLAGS}")
+else()
+  set_target_properties(DPCPP::DPCPP PROPERTIES
+    INTERFACE_COMPILE_OPTIONS "${DPCPP_FLAGS}"
+    INTERFACE_LINK_LIBRARIES ${DPCPP_LIB_DIR}
+    INTERFACE_INCLUDE_DIRECTORIES "${DPCPP_BIN_DIR}/../include/sycl")
+endif()
+
+function(add_sycl_to_target)
+  set(options)
+  set(oneValueArgs TARGET)
+  set(multiValueArgs SOURCES)
+  cmake_parse_arguments(CUTLASS_ADD_SYCL
+    "${options}"
+    "${oneValueArgs}"
+    "${multiValueArgs}"
+    ${ARGN}
+  )
+  target_compile_options(
+    ${CUTLASS_ADD_SYCL_TARGET}
+    PUBLIC
+    $<$<COMPILE_LANGUAGE:CXX>:${DPCPP_FLAGS}>
+  )
+  get_target_property(target_type ${CUTLASS_ADD_SYCL_TARGET} TYPE)
+  if (NOT target_type STREQUAL "OBJECT_LIBRARY")
+    target_link_options(${CUTLASS_ADD_SYCL_TARGET} PUBLIC ${DPCPP_FLAGS})
+  endif()
+endfunction()
+
+function(add_sycl_include_directories_to_target NAME)
+  target_include_directories(${NAME}
+    PUBLIC ${DPCPP_BIN_DIR}/../include/sycl
+    PUBLIC ${DPCPP_BIN_DIR}/../include>
+  )
+endfunction()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -48,13 +48,17 @@ function(cutlass_example_add_executable NAME)
 
   add_dependencies(cutlass_examples ${NAME})
 
+  if (NOT CUTLASS_ENABLE_SYCL)
+    SET(ADD_CUDA ON)
+  endif()
+
   target_link_libraries(
     ${NAME}
     PRIVATE
     CUTLASS
     cutlass_tools_util_includes
     $<$<BOOL:${CUTLASS_ENABLE_CUBLAS}>:nvidia::cublas>
-    cuda
+    $<$<BOOL:${ADD_CUDA}>:cuda>
     )
 
   target_include_directories(
@@ -63,6 +67,10 @@ function(cutlass_example_add_executable NAME)
     ${CUTLASS_EXAMPLES_COMMON_SOURCE_DIR}
     ${CUTLASS_EXAMPLES_UTILS_DIR}
     )
+
+  if (CUTLASS_ENABLE_SYCL)
+    add_sycl_to_target(TARGET ${NAME})
+  endif()
 
   install(
     TARGETS ${NAME}
@@ -80,68 +88,74 @@ function(cutlass_example_add_executable NAME)
 
 endfunction()
 
-foreach(EXAMPLE
-  00_basic_gemm
-  01_cutlass_utilities
-  02_dump_reg_shmem
-  03_visualize_layout
-  04_tile_iterator
-  05_batched_gemm
-  06_splitK_gemm
-  07_volta_tensorop_gemm
-  08_turing_tensorop_gemm
-  09_turing_tensorop_conv2dfprop
-  10_planar_complex
-  11_planar_complex_array
-  12_gemm_bias_relu
-  13_two_tensor_op_fusion
-  14_ampere_tf32_tensorop_gemm
-  15_ampere_sparse_tensorop_gemm
-  16_ampere_tensorop_conv2dfprop
-  17_fprop_per_channel_bias
-  18_ampere_fp64_tensorop_affine2_gemm
-  19_tensorop_canonical
-  20_simt_canonical
-  21_quaternion_gemm
-  22_quaternion_conv
-  23_ampere_gemm_operand_reduction_fusion
-  24_gemm_grouped
-  25_ampere_fprop_mainloop_fusion
-  26_ampere_wgrad_mainloop_fusion
-  27_ampere_3xtf32_fast_accurate_tensorop_gemm
-  28_ampere_3xtf32_fast_accurate_tensorop_fprop
-  29_ampere_3xtf32_fast_accurate_tensorop_complex_gemm
-  30_wgrad_split_k
-  31_basic_syrk
-  32_basic_trmm
-  33_ampere_3xtf32_tensorop_symm
-  34_transposed_conv2d
-  35_gemm_softmax
-  36_gather_scatter_fusion
-  37_gemm_layernorm_gemm_fusion
-  38_syr2k_grouped
-  cute
-  39_gemm_permute
-  41_fused_multi_head_attention
-  42_ampere_tensorop_group_conv
-  43_ell_block_sparse_gemm
-  45_dual_gemm
-  46_depthwise_simt_conv2dfprop
-  47_ampere_gemm_universal_streamk
-  48_hopper_warp_specialized_gemm
-  49_hopper_gemm_with_collective_builder
-  50_hopper_gemm_with_epilogue_swizzle
-  51_hopper_gett
-  52_hopper_gather_scatter_fusion
-  53_hopper_gemm_permute
-  54_hopper_fp8_warp_specialized_gemm
-  55_hopper_mixed_dtype_gemm
-  56_hopper_ptr_array_batched_gemm
-  57_hopper_grouped_gemm
-  58_ada_fp8_gemm
-  59_ampere_gather_scatter_conv
-  )
-
-  add_subdirectory(${EXAMPLE})
-
-endforeach()
+if (NOT CUTLASS_ENABLE_SYCL)
+  foreach(EXAMPLE
+    00_basic_gemm
+    01_cutlass_utilities
+    02_dump_reg_shmem
+    03_visualize_layout
+    04_tile_iterator
+    05_batched_gemm
+    06_splitK_gemm
+    07_volta_tensorop_gemm
+    08_turing_tensorop_gemm
+    09_turing_tensorop_conv2dfprop
+    10_planar_complex
+    11_planar_complex_array
+    12_gemm_bias_relu
+    13_two_tensor_op_fusion
+    14_ampere_tf32_tensorop_gemm
+    15_ampere_sparse_tensorop_gemm
+    16_ampere_tensorop_conv2dfprop
+    17_fprop_per_channel_bias
+    18_ampere_fp64_tensorop_affine2_gemm
+    19_tensorop_canonical
+    20_simt_canonical
+    21_quaternion_gemm
+    22_quaternion_conv
+    23_ampere_gemm_operand_reduction_fusion
+    24_gemm_grouped
+    25_ampere_fprop_mainloop_fusion
+    26_ampere_wgrad_mainloop_fusion
+    27_ampere_3xtf32_fast_accurate_tensorop_gemm
+    28_ampere_3xtf32_fast_accurate_tensorop_fprop
+    29_ampere_3xtf32_fast_accurate_tensorop_complex_gemm
+    30_wgrad_split_k
+    31_basic_syrk
+    32_basic_trmm
+    33_ampere_3xtf32_tensorop_symm
+    34_transposed_conv2d
+    35_gemm_softmax
+    36_gather_scatter_fusion
+    37_gemm_layernorm_gemm_fusion
+    38_syr2k_grouped
+    cute
+    39_gemm_permute
+    41_fused_multi_head_attention
+    42_ampere_tensorop_group_conv
+    43_ell_block_sparse_gemm
+    45_dual_gemm
+    46_depthwise_simt_conv2dfprop
+    47_ampere_gemm_universal_streamk
+    48_hopper_warp_specialized_gemm
+    49_hopper_gemm_with_collective_builder
+    50_hopper_gemm_with_epilogue_swizzle
+    51_hopper_gett
+    52_hopper_gather_scatter_fusion
+    53_hopper_gemm_permute
+    54_hopper_fp8_warp_specialized_gemm
+    55_hopper_mixed_dtype_gemm
+    56_hopper_ptr_array_batched_gemm
+    57_hopper_grouped_gemm
+    58_ada_fp8_gemm
+    59_ampere_gather_scatter_conv
+    )
+    add_subdirectory(${EXAMPLE})
+  endforeach()
+else()
+  foreach(EXAMPLE
+    cute
+    )
+    add_subdirectory(${EXAMPLE})
+  endforeach()
+endif()

--- a/examples/common/helper.h
+++ b/examples/common/helper.h
@@ -30,7 +30,9 @@
  **************************************************************************************************/
 #pragma once
 
+#if !defined(CUTLASS_ENABLE_SYCL)
 #include "cuda_runtime.h"
+#endif
 #include <iostream>
 
 /**
@@ -61,6 +63,7 @@
   }
 
 
+#if !defined(CUTLASS_ENABLE_SYCL)
 /**
  * GPU timer for recording the elapsed time across kernel(s) launched in GPU stream
  */
@@ -106,3 +109,5 @@ struct GpuTimer
         return elapsed;
     }
 };
+
+#endif

--- a/examples/cute/tutorial/sgemm_1_sycl.cpp
+++ b/examples/cute/tutorial/sgemm_1_sycl.cpp
@@ -1,0 +1,471 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2024 Codeplay Software Ltd. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+#define SYCLCOMPAT_PROFILING_ENABLED
+
+#include <syclcompat.hpp>
+
+#include <cute/tensor.hpp>
+
+#include "cutlass/util/print_error.hpp"
+#include "cutlass/util/GPU_Clock.hpp"
+
+template <class ProblemShape, class CtaTiler,
+          class TA, class AStride, class ASmemLayout, class AThreadLayout,
+          class TB, class BStride, class BSmemLayout, class BThreadLayout,
+          class TC, class CStride, class CSmemLayout, class CThreadLayout,
+          class Alpha, class Beta>
+void
+gemm_device(ProblemShape shape_MNK, CtaTiler cta_tiler,
+            TA const* A, AStride dA, ASmemLayout sA_layout, AThreadLayout tA,
+            TB const* B, BStride dB, BSmemLayout sB_layout, BThreadLayout tB,
+            TC      * C, CStride dC, CSmemLayout          , CThreadLayout tC,
+            Alpha alpha, Beta beta)
+{
+  using namespace cute;
+
+  // Preconditions
+  CUTE_STATIC_ASSERT_V(rank(shape_MNK) == Int<3>{});                   // (M, N, K)
+  CUTE_STATIC_ASSERT_V(rank(cta_tiler) == Int<3>{});                   // (BLK_M, BLK_N, BLK_K)
+
+  static_assert(is_static<AThreadLayout>::value);
+  static_assert(is_static<BThreadLayout>::value);
+  static_assert(is_static<CThreadLayout>::value);
+
+  CUTE_STATIC_ASSERT_V(size(tA) == size(tB));                          // NumThreads
+  CUTE_STATIC_ASSERT_V(size(tC) == size(tA));                          // NumThreads
+
+  CUTE_STATIC_ASSERT_V(size<0>(cta_tiler) % size<0>(tA) == Int<0>{});  // BLK_M / THR_M
+  CUTE_STATIC_ASSERT_V(size<2>(cta_tiler) % size<1>(tA) == Int<0>{});  // BLK_K / THR_K
+  CUTE_STATIC_ASSERT_V(size<1>(cta_tiler) % size<0>(tB) == Int<0>{});  // BLK_N / THR_N
+  CUTE_STATIC_ASSERT_V(size<2>(cta_tiler) % size<1>(tB) == Int<0>{});  // BLK_K / THR_K
+  CUTE_STATIC_ASSERT_V(size<0>(cta_tiler) % size<0>(tC) == Int<0>{});  // BLK_M / THR_M
+  CUTE_STATIC_ASSERT_V(size<1>(cta_tiler) % size<1>(tC) == Int<0>{});  // BLK_N / THR_N
+
+  static_assert(is_static<ASmemLayout>::value);
+  static_assert(is_static<BSmemLayout>::value);
+  static_assert(is_static<CSmemLayout>::value);
+
+  CUTE_STATIC_ASSERT_V(size<0>(ASmemLayout{}) == size<0>(cta_tiler));  // BLK_M
+  CUTE_STATIC_ASSERT_V(size<0>(CSmemLayout{}) == size<0>(cta_tiler));  // BLK_M
+  CUTE_STATIC_ASSERT_V(size<0>(BSmemLayout{}) == size<1>(cta_tiler));  // BLK_N
+  CUTE_STATIC_ASSERT_V(size<1>(CSmemLayout{}) == size<1>(cta_tiler));  // BLK_N
+  CUTE_STATIC_ASSERT_V(size<1>(ASmemLayout{}) == size<2>(cta_tiler));  // BLK_K
+  CUTE_STATIC_ASSERT_V(size<1>(BSmemLayout{}) == size<2>(cta_tiler));  // BLK_K
+
+  CUTE_STATIC_ASSERT_V(congruent(select<0,2>(shape_MNK), dA));         // dA strides for shape MK
+  CUTE_STATIC_ASSERT_V(congruent(select<1,2>(shape_MNK), dB));         // dB strides for shape NK
+  CUTE_STATIC_ASSERT_V(congruent(select<0,1>(shape_MNK), dC));         // dC strides for shape MN
+
+  //
+  // Full and Tiled Tensors
+  //
+
+  // Represent the full tensors
+  Tensor mA = make_tensor(make_gmem_ptr(A), select<0,2>(shape_MNK), dA); // (M,K)
+  Tensor mB = make_tensor(make_gmem_ptr(B), select<1,2>(shape_MNK), dB); // (N,K)
+  Tensor mC = make_tensor(make_gmem_ptr(C), select<0,1>(shape_MNK), dC); // (M,N)
+
+  // Get the appropriate blocks for this thread block
+  auto cta_coord = make_coord(syclcompat::work_group_id::x(), syclcompat::work_group_id::y(), _);  // (m,n,k)
+  Tensor gA = local_tile(mA, cta_tiler, cta_coord, Step<_1, X,_1>{});  // (BLK_M,BLK_K,k)
+  Tensor gB = local_tile(mB, cta_tiler, cta_coord, Step< X,_1,_1>{});  // (BLK_N,BLK_K,k)
+  Tensor gC = local_tile(mC, cta_tiler, cta_coord, Step<_1,_1, X>{});  // (BLK_M,BLK_N)
+
+  // Shared memory buffers
+  auto smemA = syclcompat::local_mem<TA[cosize_v<ASmemLayout>]>();
+  auto smemB = syclcompat::local_mem<TB[cosize_v<BSmemLayout>]>();
+  Tensor sA = make_tensor(make_smem_ptr(smemA), sA_layout);            // (BLK_M,BLK_K)
+  Tensor sB = make_tensor(make_smem_ptr(smemB), sB_layout);            // (BLK_N,BLK_K)
+
+  //
+  // Partition the copying of A and B tiles across the threads
+  //
+
+  // TUTORIAL: Example of simple raked partitioning of ThreadLayouts tA|tB over data A|B tiles
+
+  Tensor tAgA = local_partition(gA, tA, syclcompat::local_id::x());    // (THR_M,THR_K,k)
+  Tensor tAsA = local_partition(sA, tA, syclcompat::local_id::x());    // (THR_M,THR_K)
+
+  Tensor tBgB = local_partition(gB, tB, syclcompat::local_id::x());    // (THR_N,THR_K,k)
+  Tensor tBsB = local_partition(sB, tB, syclcompat::local_id::x());    // (THR_N,THR_K)
+
+  CUTE_STATIC_ASSERT_V(size<0>(tAgA) == size<0>(tAsA));                // THR_M
+  CUTE_STATIC_ASSERT_V(size<1>(tAgA) == size<1>(tAsA));                // THR_K
+  CUTE_STATIC_ASSERT_V(size<0>(tBgB) == size<0>(tBsB));                // THR_N
+  CUTE_STATIC_ASSERT_V(size<1>(tBgB) == size<1>(tBsB));                // THR_K
+
+  //
+  // Define A/B partitioning and C accumulators
+  //
+
+  // TUTORIAL: Example of partitioning via projections of a ThreadLayout tC
+
+  // Partition sA (M,K) by the rows of tC
+  Tensor tCsA = local_partition(sA, tC, syclcompat::local_id::x(), Step<_1, X>{});  // (THR_M,BLK_K)
+  // Partition sB (N,K) by the cols of tC
+  Tensor tCsB = local_partition(sB, tC, syclcompat::local_id::x(), Step< X,_1>{});  // (THR_N,BLK_K)
+  // Partition gC (M,N) by the tile of tC
+  Tensor tCgC = local_partition(gC, tC, syclcompat::local_id::x(), Step<_1,_1>{});  // (THR_M,THR_N)
+
+  // Allocate the accumulators -- same shape/layout as the partitioned data
+  Tensor tCrC = make_tensor_like(tCgC);                                // (THR_M,THR_N)
+
+  CUTE_STATIC_ASSERT_V(size<0>(tCrC) == size<0>(tCgC));                // THR_M
+  CUTE_STATIC_ASSERT_V(size<0>(tCrC) == size<0>(tCsA));                // THR_M
+  CUTE_STATIC_ASSERT_V(size<1>(tCrC) == size<1>(tCgC));                // THR_N
+  CUTE_STATIC_ASSERT_V(size<1>(tCrC) == size<0>(tCsB));                // THR_N
+  CUTE_STATIC_ASSERT_V(size<1>(tCsA) == size<1>(tCsB));                // BLK_K
+
+  // Clear the accumulators
+  clear(tCrC);
+
+#if 0
+  if(thread0()) {
+    print("  mA : "); print(  mA); print("\n");
+    print("  gA : "); print(  gA); print("\n");
+    print("  sA : "); print(  sA); print("\n");
+    print("tAgA : "); print(tAgA); print("\n");
+    print("tAsA : "); print(tAsA); print("\n");
+  }
+#endif
+
+#if 0
+  if(thread0()) {
+    print("  mB : "); print(  mB); print("\n");
+    print("  gB : "); print(  gB); print("\n");
+    print("  sB : "); print(  sB); print("\n");
+    print("tBgB : "); print(tBgB); print("\n");
+    print("tBsB : "); print(tBsB); print("\n");
+  }
+#endif
+
+#if 0
+  if(thread0()) {
+    print("  mC : "); print(  mC); print("\n");
+    print("  gC : "); print(  gC); print("\n");
+    print("tCsA : "); print(tCsA); print("\n");
+    print("tCsB : "); print(tCsB); print("\n");
+    print("tCgC : "); print(tCgC); print("\n");
+    print("tCrC : "); print(tCrC); print("\n");
+  }
+#endif
+
+#if 1
+
+  // TUTORIAL: Example of a simple mainloop that read tiles of data into shared memory,
+  //           and then computes on those tiles.
+  //   copy(.) operates on the global and shared memory via the tA|tB partitioning
+  //   gemm(.) operates on the shared and register memory via the tC partitioning
+
+  auto K_TILE_MAX = size<2>(tAgA);
+
+  for (int k_tile = 0; k_tile < K_TILE_MAX; ++k_tile)
+  {
+    // Copy gmem to smem with tA|tB thread-partitioned tensors
+    copy(tAgA(_,_,k_tile), tAsA);      // A   (THR_M,THR_K) -> (THR_M,THR_K)
+    copy(tBgB(_,_,k_tile), tBsB);      // B   (THR_N,THR_K) -> (THR_N,THR_K)
+
+    // TUTORIAL: The above call to copy(tAgA(_,_,k_tile), tAsA) is equivalent to
+    //   Tensor tAgAk = tAgA(_,_,k_tile);
+    //   CUTE_UNROLL
+    //   for (int i = 0; i < size(tAsA); ++i) {
+    //     tAsA(i) = tAgAk(i);
+    //   }
+
+    cp_async_fence();        // Label the end of (potential) cp.async instructions
+    cp_async_wait<0>();      // Sync on all (potential) cp.async instructions
+    syclcompat::wg_barrier();// Wait for all threads to write to smem
+
+    // Compute gemm on tC thread-partitioned smem
+    gemm(tCsA, tCsB, tCrC);            // (THR_M,THR_N) += (THR_M,BLK_K) * (THR_N,BLK_K)
+
+    // TUTORIAL: The above call to gemm(tCsA, tCsB, tCrC) is equivalent to
+    //   CUTE_UNROLL
+    //   for (int k = 0; k < size<1>(tCsA); ++k) {
+    //     CUTE_UNROLL
+    //     for (int m = 0; m < size<0>(tCrC); ++m) {
+    //       CUTE_UNROLL
+    //       for (int n = 0; n < size<1>(tCrC); ++n) {
+    //         tCrC(m,n) += tCsA(m,k) * tCsB(n,k);
+    //       }
+    //     }
+    //   }
+
+    syclcompat::wg_barrier();         // Wait for all threads to read from smem
+  }
+
+#endif
+
+  //
+  // Epilogue
+  //
+
+  axpby(alpha, tCrC, beta, tCgC);
+
+  // TUTORIAL: The above call to axpby(alpha, tCrC, beta, tCgC) is equivalent to
+  //   CUTE_UNROLL
+  //   for (int i = 0; i < size(tCsA); ++i) {
+  //     tCgC(i) = alpha * tCrC(i) + beta * tCgC(i);
+  //   }
+}
+
+// Setup params for an NT GEMM
+// Use m-major smem sA, n-major smem sB, and mn-major threads tA|tB
+template <class TA, class TB, class TC,
+          class Alpha, class Beta>
+void
+gemm_nt(int m, int n, int k,
+        Alpha alpha,
+        TA const* A, int ldA,
+        TB const* B, int ldB,
+        Beta beta,
+        TC      * C, int ldC)
+{
+  using namespace cute;
+
+  // Define shapes (dynamic)
+  auto M = int(m);
+  auto N = int(n);
+  auto K = int(k);
+  auto prob_shape = make_shape(M, N, K);                     // (M, N, K)
+
+  // Define NT strides (mixed)
+  auto dA = make_stride(Int<1>{}, ldA);                      // (dM, dK)
+  auto dB = make_stride(Int<1>{}, ldB);                      // (dN, dK)
+  auto dC = make_stride(Int<1>{}, ldC);                      // (dM, dN)
+
+  // Define CTA tile sizes (static)
+  auto bM = Int<128>{};
+  auto bN = Int<128>{};
+  auto bK = Int<  8>{};
+  auto cta_tiler = make_shape(bM, bN, bK);                   // (BLK_M, BLK_N, BLK_K)
+
+  // Define the smem layouts (static)
+  auto sA = make_layout(make_shape(bM, bK));                 // (m,k) -> smem_idx; m-major
+  auto sB = make_layout(make_shape(bN, bK));                 // (n,k) -> smem_idx; n-major
+  auto sC = make_layout(make_shape(bM, bN));                 // (m,n) -> smem_idx; m-major
+
+  // Define the thread layouts (static)
+  auto tA = make_layout(make_shape(Int<32>{}, Int< 8>{}));   // (m,k) -> thr_idx
+  auto tB = make_layout(make_shape(Int<32>{}, Int< 8>{}));   // (n,k) -> thr_idx
+  auto tC = make_layout(make_shape(Int<16>{}, Int<16>{}));   // (m,n) -> thr_idx
+
+  auto dimBlock = syclcompat::dim3(size(tC));
+  auto dimGrid  = syclcompat::dim3(size(ceil_div(M, bM)), size(ceil_div(N, bN)));
+
+  auto event = syclcompat::launch<
+      gemm_device<decltype(prob_shape), decltype(cta_tiler),
+                  TA, decltype(dA), decltype(sA), decltype(tA),
+                  TB, decltype(dB), decltype(sB), decltype(tB),
+                  TC, decltype(dC), decltype(sC), decltype(tC),
+                  Alpha, Beta>>(dimGrid, dimBlock, prob_shape, cta_tiler,
+                                A, dA, sA, tA,
+                                B, dB, sB, tB,
+                                C, dC, sC, tC,
+                                alpha, beta);
+  EventManager::getInstance().addEvent(event);
+}
+
+// Setup params for a TN GEMM
+// Use padded m-major smem sA, padded n-major smem sB, and k-major threads tA|tB
+template <class TA, class TB, class TC,
+          class Alpha, class Beta>
+void
+gemm_tn(int m, int n, int k,
+        Alpha alpha,
+        TA const* A, int ldA,
+        TB const* B, int ldB,
+        Beta beta,
+        TC      * C, int ldC)
+{
+  using namespace cute;
+
+  // Define shapes (dynamic)
+  auto M = int(m);
+  auto N = int(n);
+  auto K = int(k);
+  auto prob_shape = make_shape(M, N, K);                     // (M, N, K)
+
+  // Define TN strides (mixed)
+  auto dA = make_stride(ldA, Int<1>{});                      // (dM, dK)
+  auto dB = make_stride(ldB, Int<1>{});                      // (dN, dK)
+  auto dC = make_stride(Int<1>{}, ldC);                      // (dM, dN)
+
+  // Define CTA tile sizes (static)
+  auto bM = Int<128>{};
+  auto bN = Int<128>{};
+  auto bK = Int<  8>{};
+  auto cta_tiler = make_shape(bM, bN, bK);                   // (BLK_M, BLK_N, BLK_K)
+
+  // Define the smem layouts (static)
+  auto sA = make_layout(make_shape(bM,bK), LayoutRight{});   // (m,k) -> smem_idx; k-major
+  auto sB = make_layout(make_shape(bN,bK), LayoutRight{});   // (n,k) -> smem_idx; k-major
+  auto sC = make_layout(make_shape(bM, bN));                 // (m,n) -> smem_idx; m-major
+
+  // Define the thread layouts (static)
+  auto tA = make_layout(make_shape(Int<32>{}, Int< 8>{}), LayoutRight{});  // (m,k) -> thr_idx; k-major
+  auto tB = make_layout(make_shape(Int<32>{}, Int< 8>{}), LayoutRight{});  // (n,k) -> thr_idx; k-major
+  auto tC = make_layout(make_shape(Int<16>{}, Int<16>{}));                 // (m,n) -> thr_idx; m-major
+
+  auto dimBlock = syclcompat::dim3(size(tC));
+  auto dimGrid  = syclcompat::dim3(size(ceil_div(M, bM)), size(ceil_div(N, bN)));
+
+  auto event = syclcompat::launch<
+      gemm_device<decltype(prob_shape), decltype(cta_tiler),
+                  TA, decltype(dA), decltype(sA), decltype(tA),
+                  TB, decltype(dB), decltype(sB), decltype(tB),
+                  TC, decltype(dC), decltype(sC), decltype(tC),
+                  Alpha, Beta>>(dimGrid, dimBlock, prob_shape, cta_tiler,
+                                A, dA, sA, tA,
+                                B, dB, sB, tB,
+                                C, dC, sC, tC,
+                                alpha, beta);
+  EventManager::getInstance().addEvent(event);
+}
+
+template <class TA, class TB, class TC,
+          class Alpha, class Beta>
+void
+gemm(char transA, char transB, int m, int n, int k,
+     Alpha alpha,
+     TA const* A, int ldA,
+     TB const* B, int ldB,
+     Beta beta,
+     TC      * C, int ldC)
+{
+  if (transA == 'N' && transB == 'T') {
+    return gemm_nt(m, n, k, alpha, A, ldA, B, ldB, beta, C, ldC);
+  } else
+  if (transA == 'T' && transB == 'N') {
+    return gemm_tn(m, n, k, alpha, A, ldA, B, ldB, beta, C, ldC);
+  }
+  assert(false && "Not implemented");
+}
+
+
+int main(int argc, char** argv)
+{
+  int m = 5120;
+  if (argc >= 2)
+    sscanf(argv[1], "%d", &m);
+
+  int n = 5120;
+  if (argc >= 3)
+    sscanf(argv[2], "%d", &n);
+
+  int k = 4096;
+  if (argc >= 4)
+    sscanf(argv[3], "%d", &k);
+
+  char transA = 'N';
+  if (argc >= 5)
+    sscanf(argv[4], "%c", &transA);
+
+  char transB = 'T';
+  if (argc >= 6)
+    sscanf(argv[5], "%c", &transB);
+
+  using TA = float;
+  using TB = float;
+  using TC = float;
+  using TI = float;
+
+  TI alpha = 1.0;
+  TI beta  = 0.0;
+
+  std::cout << "M = " << m << std::endl;
+  std::cout << "N = " << n << std::endl;
+  std::cout << "K = " << k << std::endl;
+  std::cout << "C = A^" << transA << " B^" << transB << std::endl;
+
+  std::vector<TA> h_A(m*k);
+  std::vector<TB> h_B(n*k);
+  std::vector<TC> h_C(m*n);
+
+  for (int j = 0; j < m*k; ++j) h_A[j] = static_cast<TA>( 2*(rand() / double(RAND_MAX)) - 1 );
+  for (int j = 0; j < n*k; ++j) h_B[j] = static_cast<TB>( 2*(rand() / double(RAND_MAX)) - 1 );
+  for (int j = 0; j < m*n; ++j) h_C[j] = static_cast<TC>(-1);
+
+  auto d_A = syclcompat::malloc<TA>(m*k);
+  auto d_B = syclcompat::malloc<TB>(k*n);
+  auto d_C = syclcompat::malloc<TC>(m*n);
+
+  syclcompat::memcpy<TA>(d_A, h_A.data(), m*k);
+  syclcompat::memcpy<TB>(d_B, h_B.data(), k*n);
+  syclcompat::memcpy<TC>(d_C, h_C.data(), m*n);
+  
+  double gflops = (2.0*m*n*k) * 1e-9;
+
+  const int timing_iterations = 100;
+  GPU_Clock timer;
+
+  int ldA = 0, ldB = 0, ldC = m;
+
+  if (transA == 'N') {
+    ldA = m;
+  } else if (transA == 'T') {
+    ldA = k;
+  } else {
+    assert(false);
+  }
+
+  if (transB == 'N') {
+    ldB = k;
+  } else if (transB == 'T') {
+    ldB = n;
+  } else {
+    assert(false);
+  }
+  // Run once
+  gemm(transA, transB, m, n, k,
+       alpha,
+       d_A, ldA,
+       d_B, ldB,
+       beta,
+       d_C, ldC);
+  syclcompat::wait_and_throw();
+
+  // Timing iterations
+  timer.start();
+  for (int i = 0; i < timing_iterations; ++i) {
+    gemm(transA, transB, m, n, k,
+         alpha,
+         d_A, ldA,
+         d_B, ldB,
+         beta,
+         d_C, ldC);
+  }
+  double cute_time = timer.seconds() / timing_iterations;
+  printf("CUTE_GEMM:     [%6.1f]GFlop/s  (%6.4f)ms\n", gflops / cute_time, cute_time*1000);
+  return 0;
+}

--- a/examples/cute/tutorial/sgemm_2_sycl.cpp
+++ b/examples/cute/tutorial/sgemm_2_sycl.cpp
@@ -1,0 +1,523 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2024 Codeplay Software Ltd. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+#define SYCLCOMPAT_PROFILING_ENABLED
+
+#include <syclcompat.hpp>
+
+#include <cute/tensor.hpp>
+
+#include "cutlass/util/print_error.hpp"
+#include "cutlass/util/GPU_Clock.hpp"
+
+template <class ProblemShape, class CtaTiler,
+          class TA, class AStride, class ASmemLayout, class TiledCopyA,
+          class TB, class BStride, class BSmemLayout, class TiledCopyB,
+          class TC, class CStride, class CSmemLayout, class TiledMma,
+          class Alpha, class Beta>
+void
+gemm_device(ProblemShape shape_MNK, CtaTiler cta_tiler,
+            TA const* A, AStride dA, ASmemLayout sA_layout, TiledCopyA copy_a,
+            TB const* B, BStride dB, BSmemLayout sB_layout, TiledCopyB copy_b,
+            TC      * C, CStride dC, CSmemLayout          , TiledMma mma,
+            Alpha alpha, Beta beta)
+{
+  using namespace cute;
+
+  // Preconditions
+  CUTE_STATIC_ASSERT_V(rank(shape_MNK) == Int<3>{});                   // (M, N, K)
+  CUTE_STATIC_ASSERT_V(rank(cta_tiler) == Int<3>{});                   // (BLK_M, BLK_N, BLK_K)
+
+  CUTE_STATIC_ASSERT_V(size(copy_a) == size(mma));                     // NumThreads
+  CUTE_STATIC_ASSERT_V(size(copy_b) == size(mma));                     // NumThreads
+
+  static_assert(is_static<ASmemLayout>::value);
+  static_assert(is_static<BSmemLayout>::value);
+  static_assert(is_static<CSmemLayout>::value);
+
+  CUTE_STATIC_ASSERT_V(size<0>(ASmemLayout{}) == size<0>(cta_tiler));  // BLK_M
+  CUTE_STATIC_ASSERT_V(size<0>(CSmemLayout{}) == size<0>(cta_tiler));  // BLK_M
+  CUTE_STATIC_ASSERT_V(size<0>(BSmemLayout{}) == size<1>(cta_tiler));  // BLK_N
+  CUTE_STATIC_ASSERT_V(size<1>(CSmemLayout{}) == size<1>(cta_tiler));  // BLK_N
+  CUTE_STATIC_ASSERT_V(size<1>(ASmemLayout{}) == size<2>(cta_tiler));  // BLK_K
+  CUTE_STATIC_ASSERT_V(size<1>(BSmemLayout{}) == size<2>(cta_tiler));  // BLK_K
+
+  CUTE_STATIC_ASSERT_V(congruent(select<0,2>(shape_MNK), dA));         // dA strides for shape MK
+  CUTE_STATIC_ASSERT_V(congruent(select<1,2>(shape_MNK), dB));         // dB strides for shape NK
+  CUTE_STATIC_ASSERT_V(congruent(select<0,1>(shape_MNK), dC));         // dC strides for shape MN
+
+  //
+  // Full and Tiled Tensors
+  //
+
+  // Represent the full tensors
+  Tensor mA = make_tensor(make_gmem_ptr(A), select<0,2>(shape_MNK), dA); // (M,K)
+  Tensor mB = make_tensor(make_gmem_ptr(B), select<1,2>(shape_MNK), dB); // (N,K)
+  Tensor mC = make_tensor(make_gmem_ptr(C), select<0,1>(shape_MNK), dC); // (M,N)
+
+  // Get the appropriate blocks for this thread block
+  auto cta_coord = make_coord(syclcompat::work_group_id::x(), syclcompat::work_group_id::y(), _);  // (m,n,k
+  Tensor gA = local_tile(mA, cta_tiler, cta_coord, Step<_1, X,_1>{});  // (BLK_M,BLK_K,k)
+  Tensor gB = local_tile(mB, cta_tiler, cta_coord, Step< X,_1,_1>{});  // (BLK_N,BLK_K,k)
+  Tensor gC = local_tile(mC, cta_tiler, cta_coord, Step<_1,_1, X>{});  // (BLK_M,BLK_N)
+
+  // Shared memory buffers
+  auto smemA = syclcompat::local_mem<TA[cosize_v<ASmemLayout>]>();
+  auto smemB = syclcompat::local_mem<TB[cosize_v<BSmemLayout>]>();
+  Tensor sA = make_tensor(make_smem_ptr(smemA), sA_layout);            // (BLK_M,BLK_K)
+  Tensor sB = make_tensor(make_smem_ptr(smemB), sB_layout);            // (BLK_N,BLK_K)
+
+  //
+  // Partition the copying of A and B tiles across the threads
+  //
+
+  // TUTORIAL: Example of partitioning via a TiledCopy
+
+  ThrCopy thr_copy_a = copy_a.get_slice(syclcompat::local_id::x());
+  Tensor tAgA = thr_copy_a.partition_S(gA);                            // (CPY,CPY_M,CPY_K,k)
+  Tensor tAsA = thr_copy_a.partition_D(sA);                            // (CPY,CPY_M,CPY_K)
+  // Allocate registers same shape/layout as partitioned data
+  Tensor tArA = make_fragment_like(tAsA);                              // (CPY,CPY_M,CPY_K)
+
+  ThrCopy thr_copy_b = copy_b.get_slice(syclcompat::local_id::x());
+  Tensor tBgB = thr_copy_b.partition_S(gB);                            // (CPY,CPY_N,CPY_K,k)
+  Tensor tBsB = thr_copy_b.partition_D(sB);                            // (CPY,CPY_N,CPY_K)
+  // Allocate registers same shape/layout as partitioned data
+  Tensor tBrB = make_fragment_like(tBsB);                              // (CPY,CPY_N,CPY_K)
+
+  CUTE_STATIC_ASSERT_V(size<1>(tAgA) == size<1>(tAsA));                // CPY_M
+  CUTE_STATIC_ASSERT_V(size<1>(tAgA) == size<1>(tArA));                // CPY_M
+  CUTE_STATIC_ASSERT_V(size<2>(tAgA) == size<2>(tAsA));                // CPY_K
+  CUTE_STATIC_ASSERT_V(size<2>(tAgA) == size<2>(tArA));                // CPY_K
+  CUTE_STATIC_ASSERT_V(size<1>(tBgB) == size<1>(tBsB));                // CPY_N
+  CUTE_STATIC_ASSERT_V(size<1>(tBgB) == size<1>(tBrB));                // CPY_N
+  CUTE_STATIC_ASSERT_V(size<2>(tBgB) == size<2>(tBsB));                // CPY_K
+  CUTE_STATIC_ASSERT_V(size<2>(tBgB) == size<2>(tBrB));                // CPY_K
+
+  // Copy gmem to rmem for k_tile=0
+  copy(copy_a, tAgA(_,_,_,0), tArA);
+  copy(copy_b, tBgB(_,_,_,0), tBrB);
+  //
+  // Define A/B partitioning and C accumulators
+  //
+
+  // TUTORIAL: Example of partitioning via a TiledMMA
+
+  ThrMMA thr_mma = mma.get_slice(syclcompat::local_id::x());
+  Tensor tCsA = thr_mma.partition_A(sA);                               // (MMA,MMA_M,MMA_K)
+  Tensor tCsB = thr_mma.partition_B(sB);                               // (MMA,MMA_N,MMA_K)
+  Tensor tCgC = thr_mma.partition_C(gC);                               // (MMA,MMA_M,MMA_N)
+
+  // Allocate the accumulators -- same size as the projected data
+  Tensor tCrC = thr_mma.make_fragment_C(tCgC);                         // (MMA,MMA_M,MMA_N)
+
+  CUTE_STATIC_ASSERT_V(  shape(tCrC) ==   shape(tCgC));                // (MMA,MMA_M,MMA_N)
+  CUTE_STATIC_ASSERT_V(size<1>(tCgC) == size<1>(tCsA));                // MMA_M
+  CUTE_STATIC_ASSERT_V(size<2>(tCgC) == size<1>(tCsB));                // MMA_N
+  CUTE_STATIC_ASSERT_V(size<2>(tCsA) == size<2>(tCsB));                // MMA_K
+
+  // Clear the accumulators
+  clear(tCrC);
+
+#if 0
+  if(thread0()) {
+    print("  mA : "); print(  mA); print("\n");
+    print("  gA : "); print(  gA); print("\n");
+    print("  sA : "); print(  sA); print("\n");
+    print("tAgA : "); print(tAgA); print("\n");
+    print("tAsA : "); print(tAsA); print("\n");
+    print("tArA : "); print(tArA); print("\n");
+  }
+#endif
+
+#if 0
+  if(thread0()) {
+    print("  mB : "); print(  mB); print("\n");
+    print("  gB : "); print(  gB); print("\n");
+    print("  sB : "); print(  sB); print("\n");
+    print("tBgB : "); print(tBgB); print("\n");
+    print("tBsB : "); print(tBsB); print("\n");
+    print("tArA : "); print(tArA); print("\n");
+  }
+#endif
+
+#if 0
+  if(thread0()) {
+    print("  mC : "); print(  mC); print("\n");
+    print("  gC : "); print(  gC); print("\n");
+    print("tCsA : "); print(tCsA); print("\n");
+    print("tCsB : "); print(tCsB); print("\n");
+    print("tCgC : "); print(tCgC); print("\n");
+    print("tCrC : "); print(tCrC); print("\n");
+  }
+#endif
+
+#if 1
+
+  // TUTORIAL: Example of an inner loop that pipelines compute with reads
+  //           from global memory by staging through register and shared memory.
+  //   Data is read from global to registers, then to shared via the TiledCopy partitions
+  //   gemm(.) operates on the shared memory directly via the TiledMMA partitions
+
+  auto K_TILE_MAX = size<3>(tAgA);
+
+  for (int k_tile = 0; k_tile < K_TILE_MAX; ++k_tile)
+  {
+    // Copy rmem to smem with tA|tB thread-partitioned tensors
+    syclcompat::wg_barrier();         // Wait for all threads to consume smem
+    copy(tArA, tAsA);
+    copy(tBrB, tBsB);
+    syclcompat::wg_barrier();         // Wait for all threads to consume smem
+
+    // Copy gmem to rmem for k_tile+1 with tA|tB thread-partitioned tensors
+    int k_tile_next = (k_tile + 1 < K_TILE_MAX) ? k_tile + 1 : k_tile;
+    copy(copy_a, tAgA(_,_,_,k_tile_next), tArA);
+    copy(copy_b, tBgB(_,_,_,k_tile_next), tBrB);
+    // TUTORIAL: The above call to copy(copy_a, tAgA(_,_,_,k_tile_next), tArA) is equivalent to
+    //   CUTE_UNROLL
+    //   for (int k = 0; k < size<1>(tCsA); ++k) {
+    //     CUTE_UNROLL
+    //     for (int m = 0; m < size<0>(tCrC); ++m) {
+    //       copy_a.call(tAgA(_,m,k), tArA(_,m,k);
+    //     }
+    //   }
+
+    // Compute gemm on mma-partitioned smem
+    gemm(mma, tCsA, tCsB, tCrC);
+    // TUTORIAL: The above call to gemm(tCsA, tCsB, tCrC) is equivalent to
+    //   CUTE_UNROLL
+    //   for (int k = 0; k < size<1>(tCsA); ++k) {
+    //     CUTE_UNROLL
+    //     for (int m = 0; m < size<0>(tCrC); ++m) {
+    //       CUTE_UNROLL
+    //       for (int n = 0; n < size<1>(tCrC); ++n) {
+    //         mma.call(tCsA(_,m,k), tCsB(_,n,k), tCrC(_,m,n);
+    //       }
+    //     }
+    //   }
+  }
+
+#endif
+
+  //
+  // Epilogue
+  //
+
+  axpby(alpha, tCrC, beta, tCgC);
+}
+
+// Setup params for a NT GEMM
+template <class TA, class TB, class TC,
+          class Alpha, class Beta>
+void
+gemm_nt(int m, int n, int k,
+        Alpha alpha,
+        TA const* A, int ldA,
+        TB const* B, int ldB,
+        Beta beta,
+        TC      * C, int ldC)
+{
+  using namespace cute;
+
+  // Define shapes (dynamic)
+  auto M = int(m);
+  auto N = int(n);
+  auto K = int(k);
+  auto prob_shape = make_shape(M, N, K);                     // (M, N, K)
+
+  // Define NT strides (mixed)
+  auto dA = make_stride(Int<1>{}, ldA);                      // (dM, dK)
+  auto dB = make_stride(Int<1>{}, ldB);                      // (dN, dK)
+  auto dC = make_stride(Int<1>{}, ldC);                      // (dM, dN)
+
+  // Define CTA tile sizes (static)
+  auto bM = Int<128>{};
+  auto bN = Int<128>{};
+  auto bK = Int<  8>{};
+  auto cta_tiler = make_shape(bM, bN, bK);                   // (BLK_M, BLK_N, BLK_K)
+
+  // Define the smem layouts (static)
+  auto sA = make_layout(make_shape(bM, bK));                 // (m,k) -> smem_idx; m-major
+  auto sB = make_layout(make_shape(bN, bK));                 // (n,k) -> smem_idx; n-major
+  auto sC = make_layout(make_shape(bM, bN));                 // (m,n) -> smem_idx; m-major
+
+  // Define the thread layouts (static)
+
+  // TUTORIAL: Construct TiledCopy with a particular Copy_Atom to use and
+  //           define the partitioning pattern to apply.
+  // Each thread will (try to) copy 4x1 elements of type TA using 128-bit copy.
+  // Use 32x8 of these threads.
+
+  TiledCopy copyA = make_tiled_copy(Copy_Atom<UniversalCopy<uint128_t>, TA>{},
+                                    Layout<Shape<_32,_8>>{},  // Thr layout 32x8 m-major
+                                    Layout<Shape< _4,_1>>{}); // Val layout  4x1 m-major
+  TiledCopy copyB = make_tiled_copy(Copy_Atom<UniversalCopy<uint128_t>, TB>{},
+                                    Layout<Shape<_32,_8>>{},  // Thr layout 32x8 n-major
+                                    Layout<Shape< _4,_1>>{}); // Val layout  4x1 n-major
+
+  // TUTORIAL: Construct TiledMMA with a particular MMA_Atom to use and
+  //           define the partitioning pattern to apply.
+  // Use a 1x1x1 FMA on the types TC += TA * TB. Each atom requires a single thread.
+  // Reproduce that atom 16x16x1 times (m-major) across threads so that we use 256 threads.
+
+  TiledMMA mmaC = make_tiled_mma(UniversalFMA<TC,TA,TB>{},
+                                 Layout<Shape<_16,_16,_1>>{});  // 16x16x1 UniversalFMA
+
+#if 0
+  print(copyA);
+  print(copyB);
+  print(mmaC);
+#endif
+
+#if 0
+  print_latex(copyA);
+  print_latex(copyB);
+  print_latex(mmaC);
+#endif
+
+  auto dimBlock = syclcompat::dim3(size(mmaC));
+  auto dimGrid  = syclcompat::dim3(size(ceil_div(M, bM)), size(ceil_div(N, bN)));
+  auto event = syclcompat::launch<
+      gemm_device<decltype(prob_shape), decltype(cta_tiler),
+                  TA, decltype(dA), decltype(sA), decltype(copyA),
+                  TB, decltype(dB), decltype(sB), decltype(copyB),
+                  TC, decltype(dC), decltype(sC), decltype(mmaC),
+                  Alpha, Beta>>(dimGrid, dimBlock, prob_shape, cta_tiler,
+                    A, dA, sA, copyA,
+                    B, dB, sB, copyB,
+                    C, dC, sC, mmaC,
+                    alpha, beta);
+  EventManager::getInstance().addEvent(event);
+}
+
+// Setup params for a TN GEMM
+template <class TA, class TB, class TC,
+          class Alpha, class Beta>
+void
+gemm_tn(int m, int n, int k,
+        Alpha alpha,
+        TA const* A, int ldA,
+        TB const* B, int ldB,
+        Beta beta,
+        TC      * C, int ldC)
+{
+  using namespace cute;
+
+  // Define shapes (dynamic)
+  auto M = int(m);
+  auto N = int(n);
+  auto K = int(k);
+  auto prob_shape = make_shape(M, N, K);                     // (M, N, K)
+
+  // Define TN strides (mixed)
+  auto dA = make_stride(ldA, Int<1>{});                      // (dM, dK)
+  auto dB = make_stride(ldB, Int<1>{});                      // (dN, dK)
+  auto dC = make_stride(Int<1>{}, ldC);                      // (dM, dN)
+
+  // Define CTA tile sizes (static)
+  auto bM = Int<128>{};
+  auto bN = Int<128>{};
+  auto bK = Int<  8>{};
+  auto cta_tiler = make_shape(bM, bN, bK);                   // (BLK_M, BLK_N, BLK_K)
+
+  // Define the smem layouts (static)
+  auto sA = make_layout(make_shape (      bM,          bK),
+                        make_stride(Int<1>{}, bM+Int<1>{}));        // (m,k) -> smem_idx; padded m-major
+  auto sB = make_layout(make_shape (      bN,          bK),
+                        make_stride(Int<1>{}, bN+Int<1>{}));        // (n,k) -> smem_idx; padded n-major
+  auto sC = make_layout(make_shape(bM, bN));                        // (m,n) -> smem_idx
+
+  // TUTORIAL: Construct TiledCopy to define the Copy_Atom to use and the
+  //           partitioning pattern to apply.
+  // Each thread will copy 1x1 elements of type TA.
+  // Use 32x8 of these threads arranged in k-major.
+
+  TiledCopy copyA = make_tiled_copy(Copy_Atom<UniversalCopy<TA>, TA>{},
+                                    Layout<Shape<_32,_8>,Stride<_8,_1>>{}, // Thr layout 32x8 k-major
+                                    Layout<Shape< _1,_1>>{});              // Val layout  1x1
+  TiledCopy copyB = make_tiled_copy(Copy_Atom<UniversalCopy<TB>, TB>{},
+                                    Layout<Shape<_32,_8>,Stride<_8,_1>>{}, // Thr layout 32x8 k-major
+                                    Layout<Shape< _1,_1>>{});              // Val layout  1x1
+
+  // TUTORIAL: Construct TiledMMA to define the MMA_Atom to use and the
+  //           partitioning pattern to apply.
+  // Use a 1x1x1 FMA on the types TC += TA * TB. Each atom requires a single thread.
+  // Reproduce that atom 16x16x1 times (m-major) across threads so that we use 256 threads.
+
+  TiledMMA mmaC = make_tiled_mma(UniversalFMA<TC,TA,TB>{},
+                                 Layout<Shape<_16,_16,_1>>{});  // 16x16x1 TiledMMA
+
+#if 0
+  print(copyA);
+  print(copyB);
+  print(mmaC);
+#endif
+
+#if 0
+  print_latex(copyA);
+  print_latex(copyB);
+  print_latex(mmaC);
+#endif
+
+  auto dimBlock = syclcompat::dim3(size(mmaC));
+  auto dimGrid  = syclcompat::dim3(size(ceil_div(M, bM)), size(ceil_div(N, bN)));
+  auto event = syclcompat::launch<
+      gemm_device<decltype(prob_shape), decltype(cta_tiler),
+                  TA, decltype(dA), decltype(sA), decltype(copyA),
+                  TB, decltype(dB), decltype(sB), decltype(copyB),
+                  TC, decltype(dC), decltype(sC), decltype(mmaC),
+                  Alpha, Beta>>(dimGrid, dimBlock, prob_shape, cta_tiler,
+                    A, dA, sA, copyA,
+                    B, dB, sB, copyB,
+                    C, dC, sC, mmaC,
+                    alpha, beta);
+  EventManager::getInstance().addEvent(event);
+}
+
+template <class TA, class TB, class TC,
+          class Alpha, class Beta>
+void
+gemm(char transA, char transB, int m, int n, int k,
+     Alpha alpha,
+     TA const* A, int ldA,
+     TB const* B, int ldB,
+     Beta beta,
+     TC      * C, int ldC)
+{
+  if (transA == 'N' && transB == 'T') {
+    return gemm_nt(m, n, k, alpha, A, ldA, B, ldB, beta, C, ldC);
+  } else
+  if (transA == 'T' && transB == 'N') {
+    return gemm_tn(m, n, k, alpha, A, ldA, B, ldB, beta, C, ldC);
+  }
+  assert(false && "Not implemented");
+}
+
+
+int main(int argc, char** argv)
+{
+  int m = 5120;
+  if (argc >= 2)
+    sscanf(argv[1], "%d", &m);
+
+  int n = 5120;
+  if (argc >= 3)
+    sscanf(argv[2], "%d", &n);
+
+  int k = 4096;
+  if (argc >= 4)
+    sscanf(argv[3], "%d", &k);
+
+  char transA = 'N';
+  if (argc >= 5)
+    sscanf(argv[4], "%c", &transA);
+
+  char transB = 'T';
+  if (argc >= 6)
+    sscanf(argv[5], "%c", &transB);
+
+  using TA = float;
+  using TB = float;
+  using TC = float;
+  using TI = float;
+
+  TI alpha = 1.0;
+  TI beta  = 0.0;
+
+  std::cout << "M = " << m << std::endl;
+  std::cout << "N = " << n << std::endl;
+  std::cout << "K = " << k << std::endl;
+  std::cout << "C = A^" << transA << " B^" << transB << std::endl;
+
+  std::vector<TA> h_A(m*k);
+  std::vector<TB> h_B(n*k);
+  std::vector<TC> h_C(m*n);
+
+  for (int j = 0; j < m*k; ++j) h_A[j] = static_cast<TA>( 2*(rand() / double(RAND_MAX)) - 1 );
+  for (int j = 0; j < n*k; ++j) h_B[j] = static_cast<TB>( 2*(rand() / double(RAND_MAX)) - 1 );
+  for (int j = 0; j < m*n; ++j) h_C[j] = static_cast<TC>(-1);
+
+  auto d_A = syclcompat::malloc<TA>(m*k);
+  auto d_B = syclcompat::malloc<TB>(k*n);
+  auto d_C = syclcompat::malloc<TC>(m*n);
+
+  syclcompat::memcpy<TA>(d_A, h_A.data(), m*k);
+  syclcompat::memcpy<TB>(d_B, h_B.data(), k*n);
+  syclcompat::memcpy<TC>(d_C, h_C.data(), m*n);
+
+  double gflops = (2.0*m*n*k) * 1e-9;
+
+  const int timing_iterations = 100;
+  GPU_Clock timer;
+
+  int ldA = 0, ldB = 0, ldC = m;
+
+  if (transA == 'N') {
+    ldA = m;
+  } else if (transA == 'T') {
+    ldA = k;
+  } else {
+    assert(false);
+  }
+
+  if (transB == 'N') {
+    ldB = k;
+  } else if (transB == 'T') {
+    ldB = n;
+  } else {
+    assert(false);
+  }
+
+  // Run once
+  gemm(transA, transB, m, n, k,
+       alpha,
+       d_A, ldA,
+       d_B, ldB,
+       beta,
+       d_C, ldC);
+  syclcompat::wait_and_throw();
+
+  // Timing iterations
+  timer.start();
+  for (int i = 0; i < timing_iterations; ++i) {
+    gemm(transA, transB, m, n, k,
+         alpha,
+         d_A, ldA,
+         d_B, ldB,
+         beta,
+         d_C, ldC);
+  }
+  double cute_time = timer.seconds() / timing_iterations;
+  printf("CUTE_GEMM:     [%6.1f]GFlop/s  (%6.4f)ms\n", gflops / cute_time, cute_time*1000);
+
+  return 0;
+}

--- a/examples/cute/tutorial/sgemm_sm70_sycl.cpp
+++ b/examples/cute/tutorial/sgemm_sm70_sycl.cpp
@@ -1,0 +1,515 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2024 Codeplay Software Ltd. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+#define SYCLCOMPAT_PROFILING_ENABLED
+
+#include <syclcompat.hpp>
+
+#include <cute/tensor.hpp>
+
+#include "cutlass/util/print_error.hpp"
+#include "cutlass/util/GPU_Clock.hpp"
+
+template <class ProblemShape, class CtaTiler,
+          class TA, class AStride, class ASmemLayout, class TiledCopyA,
+          class TB, class BStride, class BSmemLayout, class TiledCopyB,
+          class TC, class CStride, class CSmemLayout, class TiledMma,
+          class Alpha, class Beta>
+void
+gemm_device(ProblemShape shape_MNK, CtaTiler cta_tiler,
+            TA const* A, AStride dA, ASmemLayout sA_layout, TiledCopyA copy_a,
+            TB const* B, BStride dB, BSmemLayout sB_layout, TiledCopyB copy_b,
+            TC      * C, CStride dC, CSmemLayout          , TiledMma mma,
+            Alpha alpha, Beta beta)
+{
+  using namespace cute;
+
+  // Preconditions
+  CUTE_STATIC_ASSERT_V(rank(shape_MNK) == Int<3>{});                   // (M, N, K)
+  CUTE_STATIC_ASSERT_V(rank(cta_tiler) == Int<3>{});                   // (BLK_M, BLK_N, BLK_K)
+
+  CUTE_STATIC_ASSERT_V(size(copy_a) == size(mma));                     // NumThreads
+  CUTE_STATIC_ASSERT_V(size(copy_b) == size(mma));                     // NumThreads
+
+  static_assert(is_static<ASmemLayout>::value);
+  static_assert(is_static<BSmemLayout>::value);
+  static_assert(is_static<CSmemLayout>::value);
+
+  CUTE_STATIC_ASSERT_V(size<0>(ASmemLayout{}) == size<0>(cta_tiler));  // BLK_M
+  CUTE_STATIC_ASSERT_V(size<0>(CSmemLayout{}) == size<0>(cta_tiler));  // BLK_M
+  CUTE_STATIC_ASSERT_V(size<0>(BSmemLayout{}) == size<1>(cta_tiler));  // BLK_N
+  CUTE_STATIC_ASSERT_V(size<1>(CSmemLayout{}) == size<1>(cta_tiler));  // BLK_N
+  CUTE_STATIC_ASSERT_V(size<1>(ASmemLayout{}) == size<2>(cta_tiler));  // BLK_K
+  CUTE_STATIC_ASSERT_V(size<1>(BSmemLayout{}) == size<2>(cta_tiler));  // BLK_K
+
+  CUTE_STATIC_ASSERT_V(congruent(select<0,2>(shape_MNK), dA));         // dA strides for shape MK
+  CUTE_STATIC_ASSERT_V(congruent(select<1,2>(shape_MNK), dB));         // dB strides for shape NK
+  CUTE_STATIC_ASSERT_V(congruent(select<0,1>(shape_MNK), dC));         // dC strides for shape MN
+
+  //
+  // Full and Tiled Tensors
+  //
+
+  // Represent the full tensors
+  Tensor mA = make_tensor(make_gmem_ptr(A), select<0,2>(shape_MNK), dA); // (M,K)
+  Tensor mB = make_tensor(make_gmem_ptr(B), select<1,2>(shape_MNK), dB); // (N,K)
+  Tensor mC = make_tensor(make_gmem_ptr(C), select<0,1>(shape_MNK), dC); // (M,N)
+
+  // Get the appropriate blocks for this thread block
+  auto cta_coord = make_coord(syclcompat::work_group_id::x(), syclcompat::work_group_id::y(), _);  // (m,n,k)
+  Tensor gA = local_tile(mA, cta_tiler, cta_coord, Step<_1, X,_1>{});  // (BLK_M,BLK_K,k)
+  Tensor gB = local_tile(mB, cta_tiler, cta_coord, Step< X,_1,_1>{});  // (BLK_N,BLK_K,k)
+  Tensor gC = local_tile(mC, cta_tiler, cta_coord, Step<_1,_1, X>{});  // (BLK_M,BLK_N)
+
+  // Shared memory buffers
+  auto smemA = syclcompat::local_mem<TA[cosize_v<ASmemLayout>]>();
+  auto smemB = syclcompat::local_mem<TB[cosize_v<BSmemLayout>]>();
+  Tensor sA = make_tensor(make_smem_ptr(smemA), sA_layout);            // (BLK_M,BLK_K)
+  Tensor sB = make_tensor(make_smem_ptr(smemB), sB_layout);            // (BLK_N,BLK_K)
+
+  //
+  // Partition the copying of A and B tiles across the threads
+  //
+
+  // TUTORIAL: Example of partitioning via a TiledCopy
+
+  ThrCopy thr_copy_a = copy_a.get_slice(syclcompat::local_id::x());
+  Tensor tAgA = thr_copy_a.partition_S(gA);                            // (CPY,CPY_M,CPY_K,k)
+  Tensor tAsA = thr_copy_a.partition_D(sA);                            // (CPY,CPY_M,CPY_K)
+  Tensor tArA = make_fragment_like(tAsA);                              // (CPY,CPY_M,CPY_K)
+
+  ThrCopy thr_copy_b = copy_b.get_slice(syclcompat::local_id::x());
+  Tensor tBgB = thr_copy_b.partition_S(gB);                            // (CPY,CPY_N,CPY_K,k)
+  Tensor tBsB = thr_copy_b.partition_D(sB);                            // (CPY,CPY_N,CPY_K)
+  Tensor tBrB = make_fragment_like(tBsB);                              // (CPY,CPY_N,CPY_K)
+
+  CUTE_STATIC_ASSERT_V(size<1>(tAgA) == size<1>(tAsA));                // CPY_M
+  CUTE_STATIC_ASSERT_V(size<1>(tAgA) == size<1>(tArA));                // CPY_M
+  CUTE_STATIC_ASSERT_V(size<2>(tAgA) == size<2>(tAsA));                // CPY_K
+  CUTE_STATIC_ASSERT_V(size<2>(tAgA) == size<2>(tArA));                // CPY_K
+  CUTE_STATIC_ASSERT_V(size<1>(tBgB) == size<1>(tBsB));                // CPY_N
+  CUTE_STATIC_ASSERT_V(size<1>(tBgB) == size<1>(tBrB));                // CPY_N
+  CUTE_STATIC_ASSERT_V(size<2>(tBgB) == size<2>(tBsB));                // CPY_K
+  CUTE_STATIC_ASSERT_V(size<2>(tBgB) == size<2>(tBrB));                // CPY_K
+
+  // Copy gmem to rmem for k_tile=0
+  copy(copy_a, tAgA(_,_,_,0), tArA);
+  copy(copy_b, tBgB(_,_,_,0), tBrB);
+  //
+  // Define A/B partitioning and C accumulators
+  //
+
+  // TUTORIAL: Example of partitioning via a TiledMMA
+
+  ThrMMA thr_mma = mma.get_slice(syclcompat::local_id::x());
+  Tensor tCsA = thr_mma.partition_A(sA);                               // (MMA,MMA_M,MMA_K)
+  Tensor tCsB = thr_mma.partition_B(sB);                               // (MMA,MMA_N,MMA_K)
+  Tensor tCgC = thr_mma.partition_C(gC);                               // (MMA,MMA_M,MMA_N)
+
+  // Allocate registers for pipelining
+  Tensor tCrA = thr_mma.make_fragment_A(tCsA);                         // (MMA,MMA_M,MMA_K)
+  Tensor tCrB = thr_mma.make_fragment_B(tCsB);                         // (MMA,MMA_N,MMA_K)
+  // Allocate the accumulators -- same size as the projected data
+  Tensor tCrC = thr_mma.make_fragment_C(tCgC);                         // (MMA,MMA_M,MMA_N)
+
+  CUTE_STATIC_ASSERT_V(  shape(tCrA) ==   shape(tCsA));                // (MMA,MMA_M,MMA_K)
+  CUTE_STATIC_ASSERT_V(  shape(tCrB) ==   shape(tCsB));                // (MMA,MMA_N,MMA_K)
+  CUTE_STATIC_ASSERT_V(  shape(tCrC) ==   shape(tCgC));                // (MMA,MMA_M,MMA_N)
+  CUTE_STATIC_ASSERT_V(size<1>(tCgC) == size<1>(tCsA));                // MMA_M
+  CUTE_STATIC_ASSERT_V(size<2>(tCgC) == size<1>(tCsB));                // MMA_N
+  CUTE_STATIC_ASSERT_V(size<2>(tCsA) == size<2>(tCsB));                // MMA_K
+
+  // Clear the accumulators
+  clear(tCrC);
+
+#if 0
+  if(thread0()) {
+    print("  mA : "); print(  mA); print("\n");
+    print("  gA : "); print(  gA); print("\n");
+    print("  sA : "); print(  sA); print("\n");
+    print("tAgA : "); print(tAgA); print("\n");
+    print("tAsA : "); print(tAsA); print("\n");
+    print("tArA : "); print(tArA); print("\n");
+  }
+#endif
+
+#if 0
+  if(thread0()) {
+    print("  mB : "); print(  mB); print("\n");
+    print("  gB : "); print(  gB); print("\n");
+    print("  sB : "); print(  sB); print("\n");
+    print("tBgB : "); print(tBgB); print("\n");
+    print("tBsB : "); print(tBsB); print("\n");
+    print("tArA : "); print(tArA); print("\n");
+  }
+#endif
+
+#if 0
+  if(thread0()) {
+    print("  mC : "); print(  mC); print("\n");
+    print("  gC : "); print(  gC); print("\n");
+    print("tCsA : "); print(tCsA); print("\n");
+    print("tCsB : "); print(tCsB); print("\n");
+    print("tCgC : "); print(tCgC); print("\n");
+    print("tCrC : "); print(tCrC); print("\n");
+  }
+#endif
+
+#if 1
+
+  // Copy rmem to smem
+  copy(tArA, tAsA);
+  copy(tBrB, tBsB);
+  syclcompat::wg_barrier();
+
+  //
+  // PIPELINED MAIN LOOP
+  // TUTORIAL: Example of a gemm loop that pipelines shared memory AND register memory
+  //   Data is read from global to registers, then to shared via the tA|tB partitions
+  //   Data is then copied from shared to registers in multiple waves via the tC partitions
+  //     and gemm(.) operates on the current register wave
+  //
+
+  // Load A, B shmem->regs for k_block=0
+  copy(tCsA(_,_,0), tCrA(_,_,0));
+  copy(tCsB(_,_,0), tCrB(_,_,0));
+  auto K_TILE_MAX  = size<3>(tAgA);
+  auto K_BLOCK_MAX = size<2>(tCrA);
+
+  CUTE_NO_UNROLL
+  for (int k_tile = 0; k_tile < K_TILE_MAX; ++k_tile)
+  {
+    // Pipeline the k-mode of the block registers
+    CUTE_UNROLL
+    for (int k_block = 0; k_block < K_BLOCK_MAX; ++k_block)
+    {
+      if (k_block == K_BLOCK_MAX - 1)
+      {
+        // Copy rmem to smem
+        syclcompat::wg_barrier();
+        copy(tArA, tAsA);
+        copy(tBrB, tBsB);
+        syclcompat::wg_barrier();
+      }
+
+      // Copy smem to rmem for k_block+1
+      int k_block_next = (k_block + 1) % K_BLOCK_MAX;
+      copy(tCsA(_,_,k_block_next), tCrA(_,_,k_block_next));
+      copy(tCsB(_,_,k_block_next), tCrB(_,_,k_block_next));
+      if (k_block == 0)
+      {
+        // Copy gmem to rmem for k_tile+1
+        int k_tile_next = (k_tile + 1 < K_TILE_MAX) ? k_tile + 1 : k_tile;
+        copy(copy_a, tAgA(_,_,_,k_tile_next), tArA);
+        copy(copy_b, tBgB(_,_,_,k_tile_next), tBrB);
+      }
+      // Thread-level register gemm for k_block
+      gemm(mma, tCrA(_,_,k_block), tCrB(_,_,k_block), tCrC);
+    } // k_block
+  } // k_tile
+
+#endif
+
+  //
+  // Epilogue
+  //
+
+  axpby(alpha, tCrC, beta, tCgC);
+}
+
+// Setup params for a NT GEMM
+template <class TA, class TB, class TC,
+          class Alpha, class Beta>
+void
+gemm_nt(int m, int n, int k,
+        Alpha alpha,
+        TA const* A, int ldA,
+        TB const* B, int ldB,
+        Beta beta,
+        TC      * C, int ldC)
+{
+  using namespace cute;
+
+  // Define shapes (dynamic)
+  auto M = int(m);
+  auto N = int(n);
+  auto K = int(k);
+  auto prob_shape = make_shape(M, N, K);                     // (M, N, K)
+
+  // Define NT strides (mixed)
+  auto dA = make_stride(Int<1>{}, ldA);                      // (dM, dK)
+  auto dB = make_stride(Int<1>{}, ldB);                      // (dN, dK)
+  auto dC = make_stride(Int<1>{}, ldC);                      // (dM, dN)
+
+  // Define CTA tile sizes (static)
+  auto bM = Int<128>{};
+  auto bN = Int<128>{};
+  auto bK = Int<  8>{};
+  auto cta_tiler = make_shape(bM, bN, bK);                   // (BLK_M, BLK_N, BLK_K)
+
+  // Define the smem layouts (static)
+  auto sA = make_layout(make_shape(bM, bK));                 // (m,k) -> smem_idx; m-major
+  auto sB = make_layout(make_shape(bN, bK));                 // (n,k) -> smem_idx; n-major
+  auto sC = make_layout(make_shape(bM, bN));                 // (m,n) -> smem_idx; m-major
+
+  // Define the thread layouts (static)
+  TiledCopy copyA = make_tiled_copy(Copy_Atom<UniversalCopy<uint128_t>, TA>{},
+                                    Layout<Shape<_32,_8>>{},  // Thr layout 32x8 m-major
+                                    Layout<Shape< _4,_1>>{}); // Val layout  4x1 m-major
+  TiledCopy copyB = make_tiled_copy(Copy_Atom<UniversalCopy<uint128_t>, TB>{},
+                                    Layout<Shape<_32,_8>>{},  // Thr layout 32x8 n-major
+                                    Layout<Shape< _4,_1>>{}); // Val layout  4x1 n-major
+
+  TiledMMA mmaC = make_tiled_mma(UniversalFMA<TC,TA,TB>{},
+                                 Layout<Shape<_16,_16,_1>>{});  // 16x16x1 TiledMMA
+
+#if 0
+  print(copyA);
+  print(copyB);
+  print(mmaC);
+#endif
+
+#if 0
+  print_latex(copyA);
+  print_latex(copyB);
+  print_latex(mmaC);
+#endif
+
+  auto dimBlock = syclcompat::dim3(size(mmaC));
+  auto dimGrid  = syclcompat::dim3(size(ceil_div(M, bM)), size(ceil_div(N, bN)));
+  auto event = syclcompat::launch<
+      gemm_device<decltype(prob_shape), decltype(cta_tiler),
+                  TA, decltype(dA), decltype(sA), decltype(copyA),
+                  TB, decltype(dB), decltype(sB), decltype(copyB),
+                  TC, decltype(dC), decltype(sC), decltype(mmaC),
+                  Alpha, Beta>>(dimGrid, dimBlock, prob_shape, cta_tiler,
+                    A, dA, sA, copyA,
+                    B, dB, sB, copyB,
+                    C, dC, sC, mmaC,
+                    alpha, beta);
+  EventManager::getInstance().addEvent(event);
+}
+
+// Setup params for a TN GEMM
+template <class TA, class TB, class TC,
+          class Alpha, class Beta>
+void
+gemm_tn(int m, int n, int k,
+        Alpha alpha,
+        TA const* A, int ldA,
+        TB const* B, int ldB,
+        Beta beta,
+        TC      * C, int ldC)
+{
+  using namespace cute;
+
+  // Define shapes (dynamic)
+  auto M = int(m);
+  auto N = int(n);
+  auto K = int(k);
+  auto prob_shape = make_shape(M, N, K);                     // (M, N, K)
+
+  // Define TN strides (mixed)
+  auto dA = make_stride(ldA, Int<1>{});                      // (dM, dK)
+  auto dB = make_stride(ldB, Int<1>{});                      // (dN, dK)
+  auto dC = make_stride(Int<1>{}, ldC);                      // (dM, dN)
+
+  // Define CTA tile sizes (static)
+  auto bM = Int<128>{};
+  auto bN = Int<128>{};
+  auto bK = Int<  8>{};
+  auto cta_tiler = make_shape(bM, bN, bK);                   // (BLK_M, BLK_N, BLK_K)
+
+  // Define the smem layouts (static)
+  auto sA = make_layout(make_shape (      bM,          bK),
+                        make_stride(Int<1>{}, bM+Int<1>{}));        // (m,k) -> smem_idx; padded m-major
+  auto sB = make_layout(make_shape (      bN,          bK),
+                        make_stride(Int<1>{}, bN+Int<1>{}));        // (n,k) -> smem_idx; padded n-major
+  auto sC = make_layout(make_shape(bM, bN));                        // (m,n) -> smem_idx
+
+  // Define the thread layouts (static)
+
+  TiledCopy copyA = make_tiled_copy(Copy_Atom<UniversalCopy<TA>, TA>{},
+                                    Layout<Shape<_32,_8>,Stride<_8,_1>>{}, // Thr layout 32x8 k-major
+                                    Layout<Shape< _1,_1>>{});              // Val layout  1x1
+  TiledCopy copyB = make_tiled_copy(Copy_Atom<UniversalCopy<TB>, TB>{},
+                                    Layout<Shape<_32,_8>,Stride<_8,_1>>{}, // Thr layout 32x8 k-major
+                                    Layout<Shape< _1,_1>>{});              // Val layout  1x1
+
+  TiledMMA mmaC = make_tiled_mma(UniversalFMA<TC,TA,TB>{},
+                                 Layout<Shape<_16,_16,_1>>{});  // 16x16x1 TiledMMA
+
+#if 0
+  print(copyA);
+  print(copyB);
+  print(mmaC);
+#endif
+
+#if 0
+  print_latex(copyA);
+  print_latex(copyB);
+  print_latex(mmaC);
+#endif
+
+  auto dimBlock = syclcompat::dim3(size(mmaC));
+  auto dimGrid  = syclcompat::dim3(size(ceil_div(M, bM)), size(ceil_div(N, bN)));
+  auto event = syclcompat::launch<
+      gemm_device<decltype(prob_shape), decltype(cta_tiler),
+                  TA, decltype(dA), decltype(sA), decltype(copyA),
+                  TB, decltype(dB), decltype(sB), decltype(copyB),
+                  TC, decltype(dC), decltype(sC), decltype(mmaC),
+                  Alpha, Beta>>(dimGrid, dimBlock, prob_shape, cta_tiler,
+                    A, dA, sA, copyA,
+                    B, dB, sB, copyB,
+                    C, dC, sC, mmaC,
+                    alpha, beta);
+  EventManager::getInstance().addEvent(event);
+}
+
+template <class TA, class TB, class TC,
+          class Alpha, class Beta>
+void
+gemm(char transA, char transB, int m, int n, int k,
+     Alpha alpha,
+     TA const* A, int ldA,
+     TB const* B, int ldB,
+     Beta beta,
+     TC      * C, int ldC)
+{
+  if (transA == 'N' && transB == 'T') {
+    return gemm_nt(m, n, k, alpha, A, ldA, B, ldB, beta, C, ldC);
+  } else
+  if (transA == 'T' && transB == 'N') {
+    return gemm_tn(m, n, k, alpha, A, ldA, B, ldB, beta, C, ldC);
+  }
+  assert(false && "Not implemented");
+}
+
+
+int main(int argc, char** argv)
+{
+  int m = 5120;
+  if (argc >= 2)
+    sscanf(argv[1], "%d", &m);
+
+  int n = 5120;
+  if (argc >= 3)
+    sscanf(argv[2], "%d", &n);
+
+  int k = 4096;
+  if (argc >= 4)
+    sscanf(argv[3], "%d", &k);
+
+  char transA = 'N';
+  if (argc >= 5)
+    sscanf(argv[4], "%c", &transA);
+
+  char transB = 'T';
+  if (argc >= 6)
+    sscanf(argv[5], "%c", &transB);
+
+  using TA = float;
+  using TB = float;
+  using TC = float;
+  using TI = float;
+
+  TI alpha = 1.0;
+  TI beta  = 0.0;
+
+  std::cout << "M = " << m << std::endl;
+  std::cout << "N = " << n << std::endl;
+  std::cout << "K = " << k << std::endl;
+  std::cout << "C = A^" << transA << " B^" << transB << std::endl;
+
+  std::vector<TA> h_A(m*k);
+  std::vector<TB> h_B(n*k);
+  std::vector<TC> h_C(m*n);
+
+  for (int j = 0; j < m*k; ++j) h_A[j] = static_cast<TA>( 2*(rand() / double(RAND_MAX)) - 1 );
+  for (int j = 0; j < n*k; ++j) h_B[j] = static_cast<TB>( 2*(rand() / double(RAND_MAX)) - 1 );
+  for (int j = 0; j < m*n; ++j) h_C[j] = static_cast<TC>(-1);
+
+  auto d_A = syclcompat::malloc<TA>(m*k);
+  auto d_B = syclcompat::malloc<TB>(k*n);
+  auto d_C = syclcompat::malloc<TC>(m*n);
+
+  syclcompat::memcpy<TA>(d_A, h_A.data(), m*k);
+  syclcompat::memcpy<TB>(d_B, h_B.data(), k*n);
+  syclcompat::memcpy<TC>(d_C, h_C.data(), m*n);
+
+  double gflops = (2.0*m*n*k) * 1e-9;
+
+  const int timing_iterations = 100;
+  GPU_Clock timer;
+
+  int ldA = 0, ldB = 0, ldC = m;
+
+  if (transA == 'N') {
+    ldA = m;
+  } else if (transA == 'T') {
+    ldA = k;
+  } else {
+    assert(false);
+  }
+
+  if (transB == 'N') {
+    ldB = k;
+  } else if (transB == 'T') {
+    ldB = n;
+  } else {
+    assert(false);
+  }
+
+  // Run once
+  gemm(transA, transB, m, n, k,
+       alpha,
+       d_A, ldA,
+       d_B, ldB,
+       beta,
+       d_C, ldC);
+  syclcompat::wait_and_throw();
+
+  // Timing iterations
+  timer.start();
+  for (int i = 0; i < timing_iterations; ++i) {
+    gemm(transA, transB, m, n, k,
+         alpha,
+         d_A, ldA,
+         d_B, ldB,
+         beta,
+         d_C, ldC);
+  }
+  double cute_time = timer.seconds() / timing_iterations;
+  printf("CUTE_GEMM:     [%6.1f]GFlop/s  (%6.4f)ms\n", gflops / cute_time, cute_time*1000);
+
+  return 0;
+}

--- a/examples/cute/tutorial/sgemm_sm80_sycl.cpp
+++ b/examples/cute/tutorial/sgemm_sm80_sycl.cpp
@@ -1,0 +1,556 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2024 Codeplay Software Ltd. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+#define SYCLCOMPAT_PROFILING_ENABLED
+
+#include <syclcompat.hpp>
+
+#include <cute/tensor.hpp>
+
+#include "cutlass/util/print_error.hpp"
+#include "cutlass/util/GPU_Clock.hpp"
+
+template <class ProblemShape, class CtaTiler,
+          class TA, class AStride, class ASmemLayout, class TiledCopyA,
+          class TB, class BStride, class BSmemLayout, class TiledCopyB,
+          class TC, class CStride, class CSmemLayout, class TiledMma,
+          class Alpha, class Beta>
+void
+gemm_device(ProblemShape shape_MNK, CtaTiler cta_tiler,
+            TA const* A, AStride dA, ASmemLayout sA_layout, TiledCopyA copy_a,
+            TB const* B, BStride dB, BSmemLayout sB_layout, TiledCopyB copy_b,
+            TC      * C, CStride dC, CSmemLayout          , TiledMma mma,
+            Alpha alpha, Beta beta)
+{
+  using namespace cute;
+
+  // Preconditions
+  CUTE_STATIC_ASSERT_V(rank(shape_MNK) == Int<3>{});                   // (M, N, K)
+  CUTE_STATIC_ASSERT_V(rank(cta_tiler) == Int<3>{});                   // (BLK_M, BLK_N, BLK_K)
+
+  CUTE_STATIC_ASSERT_V(size(copy_a) == size(mma));                     // NumThreads
+  CUTE_STATIC_ASSERT_V(size(copy_b) == size(mma));                     // NumThreads
+
+  static_assert(is_static<ASmemLayout>::value);
+  static_assert(is_static<BSmemLayout>::value);
+  static_assert(is_static<CSmemLayout>::value);
+
+  CUTE_STATIC_ASSERT_V(size<0>(ASmemLayout{}) == size<0>(cta_tiler));  // BLK_M
+  CUTE_STATIC_ASSERT_V(size<0>(CSmemLayout{}) == size<0>(cta_tiler));  // BLK_M
+  CUTE_STATIC_ASSERT_V(size<0>(BSmemLayout{}) == size<1>(cta_tiler));  // BLK_N
+  CUTE_STATIC_ASSERT_V(size<1>(CSmemLayout{}) == size<1>(cta_tiler));  // BLK_N
+  CUTE_STATIC_ASSERT_V(size<1>(ASmemLayout{}) == size<2>(cta_tiler));  // BLK_K
+  CUTE_STATIC_ASSERT_V(size<1>(BSmemLayout{}) == size<2>(cta_tiler));  // BLK_K
+
+  CUTE_STATIC_ASSERT_V(congruent(select<0,2>(shape_MNK), dA));         // dA strides for shape MK
+  CUTE_STATIC_ASSERT_V(congruent(select<1,2>(shape_MNK), dB));         // dB strides for shape NK
+  CUTE_STATIC_ASSERT_V(congruent(select<0,1>(shape_MNK), dC));         // dC strides for shape MN
+
+  //
+  // Full and Tiled Tensors
+  //
+
+  // Represent the full tensors
+  Tensor mA = make_tensor(make_gmem_ptr(A), select<0,2>(shape_MNK), dA); // (M,K)
+  Tensor mB = make_tensor(make_gmem_ptr(B), select<1,2>(shape_MNK), dB); // (N,K)
+  Tensor mC = make_tensor(make_gmem_ptr(C), select<0,1>(shape_MNK), dC); // (M,N)
+
+  // Get the appropriate blocks for this thread block
+  auto cta_coord = make_coord(syclcompat::work_group_id::x(), syclcompat::work_group_id::y(), _);  // (m,n,k)
+  Tensor gA = local_tile(mA, cta_tiler, cta_coord, Step<_1, X,_1>{});  // (BLK_M,BLK_K,k)
+  Tensor gB = local_tile(mB, cta_tiler, cta_coord, Step< X,_1,_1>{});  // (BLK_N,BLK_K,k)
+  Tensor gC = local_tile(mC, cta_tiler, cta_coord, Step<_1,_1, X>{});  // (BLK_M,BLK_N)
+
+  // Shared memory buffers
+  auto smemA = syclcompat::local_mem<TA[cosize_v<ASmemLayout>]>();
+  auto smemB = syclcompat::local_mem<TB[cosize_v<BSmemLayout>]>();
+  Tensor sA = make_tensor(make_smem_ptr(smemA), sA_layout);            // (BLK_M,BLK_K,PIPE)
+  Tensor sB = make_tensor(make_smem_ptr(smemB), sB_layout);            // (BLK_N,BLK_K,PIPE)
+
+  //
+  // Partition the copying of A and B tiles across the threads
+  //
+
+  ThrCopy thr_copy_a = copy_a.get_slice(syclcompat::local_id::x());
+  Tensor tAgA = thr_copy_a.partition_S(gA);                            // (CPY,CPY_M,CPY_K,k)
+  Tensor tAsA = thr_copy_a.partition_D(sA);                            // (CPY,CPY_M,CPY_K,PIPE)
+
+  ThrCopy thr_copy_b = copy_b.get_slice(syclcompat::local_id::x());
+  Tensor tBgB = thr_copy_b.partition_S(gB);                            // (CPY,CPY_N,CPY_K,k)
+  Tensor tBsB = thr_copy_b.partition_D(sB);                            // (CPY,CPY_N,CPY_K,PIPE)
+
+  CUTE_STATIC_ASSERT_V(size<1>(tAgA) == size<1>(tAsA));                // CPY_M
+  CUTE_STATIC_ASSERT_V(size<2>(tAgA) == size<2>(tAsA));                // CPY_K
+  CUTE_STATIC_ASSERT_V(size<1>(tBgB) == size<1>(tBsB));                // CPY_N
+  CUTE_STATIC_ASSERT_V(size<2>(tBgB) == size<2>(tBsB));                // CPY_K
+
+  //
+  // PREFETCH
+  //
+
+  auto K_PIPE_MAX = size<3>(tAsA);
+
+  // Total count of tiles
+  int k_tile_count = size<3>(tAgA);
+  // Current tile index in gmem to read from
+  int k_tile_next = 0;
+
+  // Start async loads for all pipes but the last
+  CUTE_UNROLL
+  for (int k_pipe = 0; k_pipe < K_PIPE_MAX-1; ++k_pipe) {
+    copy(copy_a, tAgA(_,_,_,k_tile_next), tAsA(_,_,_,k_pipe));
+    copy(copy_b, tBgB(_,_,_,k_tile_next), tBsB(_,_,_,k_pipe));
+    cp_async_fence();
+    --k_tile_count;
+    if (k_tile_count > 0) { ++k_tile_next; }
+  }
+
+  //
+  // Define A/B partitioning and C accumulators
+  //
+
+  ThrMMA thr_mma = mma.get_slice(syclcompat::local_id::x());
+  Tensor tCsA = thr_mma.partition_A(sA);                               // (MMA,MMA_M,MMA_K,PIPE)
+  Tensor tCsB = thr_mma.partition_B(sB);                               // (MMA,MMA_N,MMA_K,PIPE)
+  Tensor tCgC = thr_mma.partition_C(gC);                               // (MMA,MMA_M,MMA_N)
+
+  // Allocate registers for pipelining
+  Tensor tCrA = thr_mma.make_fragment_A(tCsA(_,_,_,0));                // (MMA,MMA_M,MMA_K)
+  Tensor tCrB = thr_mma.make_fragment_B(tCsB(_,_,_,0));                // (MMA,MMA_N,MMA_K)
+  // Allocate the accumulators -- same size as the projected data
+  Tensor tCrC = thr_mma.make_fragment_C(tCgC);                         // (MMA,MMA_M,MMA_N)
+
+  CUTE_STATIC_ASSERT_V(  shape(tCrA) ==   shape(tCsA));                // (MMA,MMA_M,MMA_K)
+  CUTE_STATIC_ASSERT_V(  shape(tCrB) ==   shape(tCsB));                // (MMA,MMA_N,MMA_K)
+  CUTE_STATIC_ASSERT_V(  shape(tCrC) ==   shape(tCgC));                // (MMA,MMA_M,MMA_N)
+  CUTE_STATIC_ASSERT_V(size<1>(tCgC) == size<1>(tCsA));                // MMA_M
+  CUTE_STATIC_ASSERT_V(size<2>(tCgC) == size<1>(tCsB));                // MMA_N
+  CUTE_STATIC_ASSERT_V(size<2>(tCsA) == size<2>(tCsB));                // MMA_K
+
+  // Clear the accumulators
+  clear(tCrC);
+
+#if 0
+  if(thread0()) {
+    print("  mA : "); print(  mA); print("\n");
+    print("  gA : "); print(  gA); print("\n");
+    print("  sA : "); print(  sA); print("\n");
+    print("tAgA : "); print(tAgA); print("\n");
+    print("tAsA : "); print(tAsA); print("\n");
+  }
+#endif
+
+#if 0
+  if(thread0()) {
+    print("  mB : "); print(  mB); print("\n");
+    print("  gB : "); print(  gB); print("\n");
+    print("  sB : "); print(  sB); print("\n");
+    print("tBgB : "); print(tBgB); print("\n");
+    print("tBsB : "); print(tBsB); print("\n");
+  }
+#endif
+
+#if 0
+  if(thread0()) {
+    print("  mC : "); print(  mC); print("\n");
+    print("  gC : "); print(  gC); print("\n");
+    print("tCsA : "); print(tCsA); print("\n");
+    print("tCsB : "); print(tCsB); print("\n");
+    print("tCgC : "); print(tCgC); print("\n");
+    print("tCrA : "); print(tCrA); print("\n");
+    print("tCrB : "); print(tCrB); print("\n");
+    print("tCrC : "); print(tCrC); print("\n");
+  }
+#endif
+
+#if 1
+
+  // Current pipe index in smem to read from
+  int smem_pipe_read  = 0;
+  // Current pipe index in smem to write to
+  int smem_pipe_write = K_PIPE_MAX-1;
+
+  // Pipe slice
+  Tensor tCsA_p = tCsA(_,_,_,smem_pipe_read);
+  Tensor tCsB_p = tCsB(_,_,_,smem_pipe_read);
+
+  // Size of the register pipeline
+  auto K_BLOCK_MAX = size<2>(tCrA);
+
+  // PREFETCH register pipeline
+  if (K_BLOCK_MAX > 1) {
+    // Wait until our first prefetched tile is loaded in
+    cp_async_wait<K_PIPE_MAX-2>();
+    syclcompat::wg_barrier();
+
+    // Prefetch the first rmem from the first k-tile
+    copy(tCsA_p(_,_,Int<0>{}), tCrA(_,_,Int<0>{}));
+    copy(tCsB_p(_,_,Int<0>{}), tCrB(_,_,Int<0>{}));
+  }
+
+  //
+  // PIPELINED MAIN LOOP
+  // TUTORIAL: Example of a gemm loop that pipelines shared memory using SM80's cp.async instructions
+  //           and explicit pipelines in shared memory.
+  //   Data is read from global(k_tile_next) to shared(smem_pipe_write).
+  //   Data is read from shared(smem_pipe_read) to registers(k_block_next).
+  //   Data is computed on registers(b_block).
+  //
+  //   This allows all copies and compute to overlap:
+  //     Copy from gmem->smem can overlap with copies from smem->rmem and compute on rmem.
+  //     Copy from smem->rmem can overlap with compute on rmem.
+  //
+
+  CUTE_NO_UNROLL
+  while (k_tile_count > -(K_PIPE_MAX-1))
+  {
+    CUTE_UNROLL
+    for (int k_block = 0; k_block < K_BLOCK_MAX; ++k_block)
+    {
+      if (k_block == K_BLOCK_MAX - 1)
+      {
+        // Slice the smem_pipe_read smem
+        tCsA_p = tCsA(_,_,_,smem_pipe_read);
+        tCsB_p = tCsB(_,_,_,smem_pipe_read);
+
+        // Commit the smem for smem_pipe_read
+        cp_async_wait<K_PIPE_MAX-2>();
+        syclcompat::wg_barrier();
+      }
+
+      // Load A, B shmem->regs for k_block+1
+      auto k_block_next = (k_block + Int<1>{}) % K_BLOCK_MAX;      // static
+      copy(tCsA_p(_,_,k_block_next), tCrA(_,_,k_block_next));
+      copy(tCsB_p(_,_,k_block_next), tCrB(_,_,k_block_next));
+      // Copy gmem to smem before computing gemm on each k-pipe
+      if (k_block == 0)
+      {
+        copy(copy_a, tAgA(_,_,_,k_tile_next), tAsA(_,_,_,smem_pipe_write));
+        copy(copy_b, tBgB(_,_,_,k_tile_next), tBsB(_,_,_,smem_pipe_write));
+        cp_async_fence();
+
+        // Advance the gmem tile
+        --k_tile_count;
+        if (k_tile_count > 0) { ++k_tile_next; }
+
+        // Advance the smem pipe
+        smem_pipe_write = smem_pipe_read;
+        ++smem_pipe_read;
+        smem_pipe_read = (smem_pipe_read == K_PIPE_MAX) ? 0 : smem_pipe_read;
+      }
+      // Thread-level register gemm for k_block
+      gemm(mma, tCrA(_,_,k_block), tCrB(_,_,k_block), tCrC);
+    }
+
+  }
+
+#endif
+
+  //
+  // Epilogue
+  //
+
+  axpby(alpha, tCrC, beta, tCgC);
+}
+
+// Setup params for a NT GEMM
+template <class TA, class TB, class TC,
+          class Alpha, class Beta>
+void
+gemm_nt(int m, int n, int k,
+        Alpha alpha,
+        TA const* A, int ldA,
+        TB const* B, int ldB,
+        Beta beta,
+        TC      * C, int ldC)
+{
+  using namespace cute;
+
+  // Define shapes (dynamic)
+  auto M = int(m);
+  auto N = int(n);
+  auto K = int(k);
+  auto prob_shape = make_shape(M, N, K);                     // (M, N, K)
+
+  // Define NT strides (mixed)
+  auto dA = make_stride(Int<1>{}, ldA);                      // (dM, dK)
+  auto dB = make_stride(Int<1>{}, ldB);                      // (dN, dK)
+  auto dC = make_stride(Int<1>{}, ldC);                      // (dM, dN)
+
+  // Define CTA tile sizes (static)
+  auto bM = Int<128>{};
+  auto bN = Int<128>{};
+  auto bK = Int<  8>{};
+  auto cta_tiler = make_shape(bM, bN, bK);                   // (BLK_M, BLK_N, BLK_K)
+  auto bP = Int<3>{};  // Pipeline
+
+  // Define the smem layouts (static)
+  auto sA = make_layout(make_shape(bM, bK, bP));             // (m,k,p) -> smem_idx; m-major
+  auto sB = make_layout(make_shape(bN, bK, bP));             // (n,k,p) -> smem_idx; n-major
+  auto sC = make_layout(make_shape(bM, bN));                 // (m,n) -> smem_idx; m-major
+
+  // Define the thread layouts (static)
+
+  TiledCopy copyA = make_tiled_copy(Copy_Atom<SM80_CP_ASYNC_CACHEALWAYS<uint128_t>, TA>{},
+                                    Layout<Shape<_32,_8>>{}, // Thr layout 32x8 m-major
+                                    Layout<Shape< _4,_1>>{});// Val layout  4x1 m-major
+  TiledCopy copyB = make_tiled_copy(Copy_Atom<SM80_CP_ASYNC_CACHEALWAYS<uint128_t>, TB>{},
+                                    Layout<Shape<_32,_8>>{}, // Thr layout 32x8 n-major
+                                    Layout<Shape< _4,_1>>{});// Val layout  4x1 n-major
+
+  TiledMMA mmaC = make_tiled_mma(UniversalFMA<TC,TA,TB>{},
+                                 Layout<Shape<_16,_16,_1>>{});  // 16x16x1 TiledMMA
+
+#if 0
+  print(copyA);
+  print(copyB);
+  print(mmaC);
+#endif
+
+#if 0
+  print_latex(copyA);
+  print_latex(copyB);
+  print_latex(mmaC);
+#endif
+
+  auto dimBlock = syclcompat::dim3(size(mmaC));
+  auto dimGrid  = syclcompat::dim3(size(ceil_div(M, bM)), size(ceil_div(N, bN)));
+  auto event = syclcompat::launch<
+      gemm_device<decltype(prob_shape), decltype(cta_tiler),
+                  TA, decltype(dA), decltype(sA), decltype(copyA),
+                  TB, decltype(dB), decltype(sB), decltype(copyB),
+                  TC, decltype(dC), decltype(sC), decltype(mmaC),
+                  Alpha, Beta>>(dimGrid, dimBlock, prob_shape, cta_tiler,
+                    A, dA, sA, copyA,
+                    B, dB, sB, copyB,
+                    C, dC, sC, mmaC,
+                    alpha, beta);
+  EventManager::getInstance().addEvent(event);
+}
+
+// Setup params for a NT GEMM
+template <class TA, class TB, class TC,
+          class Alpha, class Beta>
+void
+gemm_tn(int m, int n, int k,
+        Alpha alpha,
+        TA const* A, int ldA,
+        TB const* B, int ldB,
+        Beta beta,
+        TC      * C, int ldC)
+{
+  using namespace cute;
+
+  // Define shapes (dynamic)
+  auto M = int(m);
+  auto N = int(n);
+  auto K = int(k);
+  auto prob_shape = make_shape(M, N, K);                     // (M, N, K)
+
+  // Define TN strides (mixed)
+  auto dA = make_stride(ldA, Int<1>{});                      // (dM, dK)
+  auto dB = make_stride(ldB, Int<1>{});                      // (dN, dK)
+  auto dC = make_stride(Int<1>{}, ldC);                      // (dM, dN)
+
+  // Define CTA tile sizes (static)
+  auto bM = Int<128>{};
+  auto bN = Int<128>{};
+  auto bK = Int<  8>{};
+  auto cta_tiler = make_shape(bM, bN, bK);                   // (BLK_M, BLK_N, BLK_K)
+  auto bP = Int<3>{};  // Pipeline
+
+  // Define the smem layouts (static)
+  auto sA_atom = make_layout(make_shape (      bM,          bK),
+                             make_stride(Int<1>{}, bM+Int<1>{}));   // (m,k) -> smem_idx; padded m-major
+  auto sB_atom = make_layout(make_shape (      bN,          bK),
+                             make_stride(Int<1>{}, bN+Int<1>{}));   // (n,k) -> smem_idx; padded n-major
+  auto sA = tile_to_shape(sA_atom, make_shape(bM, bK, bP));
+  auto sB = tile_to_shape(sA_atom, make_shape(bN, bK, bP));
+  auto sC = make_layout(make_shape(bM, bN));                        // (m,n) -> smem_idx
+
+  // Define the thread layouts (static)
+
+  TiledCopy copyA = make_tiled_copy(Copy_Atom<SM80_CP_ASYNC_CACHEALWAYS<TA>, TA>{},
+                                    Layout<Shape<_32,_8>,Stride<_8,_1>>{}, // Thr layout 32x8 k-major
+                                    Layout<Shape< _1,_1>>{});              // Val layout  1x1
+  TiledCopy copyB = make_tiled_copy(Copy_Atom<SM80_CP_ASYNC_CACHEALWAYS<TB>, TB>{},
+                                    Layout<Shape<_32,_8>,Stride<_8,_1>>{}, // Thr layout 32x8 k-major
+                                    Layout<Shape< _1,_1>>{});              // Val layout  1x1
+
+  TiledMMA mmaC = make_tiled_mma(UniversalFMA<TC,TA,TB>{},
+                                 Layout<Shape<_16,_16,_1>>{});  // 16x16x1 TiledMMA
+
+#if 0
+  print(copyA);
+  print(copyB);
+  print(mmaC);
+#endif
+
+#if 0
+  print_latex(copyA);
+  print_latex(copyB);
+  print_latex(mmaC);
+#endif
+
+  auto dimBlock = syclcompat::dim3(size(mmaC));
+  auto dimGrid  = syclcompat::dim3(size(ceil_div(M, bM)), size(ceil_div(N, bN)));
+  auto event = syclcompat::launch<
+      gemm_device<decltype(prob_shape), decltype(cta_tiler),
+                  TA, decltype(dA), decltype(sA), decltype(copyA),
+                  TB, decltype(dB), decltype(sB), decltype(copyB),
+                  TC, decltype(dC), decltype(sC), decltype(mmaC),
+                  Alpha, Beta>>(dimGrid, dimBlock, prob_shape, cta_tiler,
+                    A, dA, sA, copyA,
+                    B, dB, sB, copyB,
+                    C, dC, sC, mmaC,
+                    alpha, beta);
+  EventManager::getInstance().addEvent(event);
+}
+
+template <class TA, class TB, class TC,
+          class Alpha, class Beta>
+void
+gemm(char transA, char transB, int m, int n, int k,
+     Alpha alpha,
+     TA const* A, int ldA,
+     TB const* B, int ldB,
+     Beta beta,
+     TC      * C, int ldC)
+{
+  if (transA == 'N' && transB == 'T') {
+    return gemm_nt(m, n, k, alpha, A, ldA, B, ldB, beta, C, ldC);
+  } else
+  if (transA == 'T' && transB == 'N') {
+    return gemm_tn(m, n, k, alpha, A, ldA, B, ldB, beta, C, ldC);
+  }
+  assert(false && "Not implemented");
+}
+
+
+int main(int argc, char** argv)
+{
+  int m = 5120;
+  if (argc >= 2)
+    sscanf(argv[1], "%d", &m);
+
+  int n = 5120;
+  if (argc >= 3)
+    sscanf(argv[2], "%d", &n);
+
+  int k = 4096;
+  if (argc >= 4)
+    sscanf(argv[3], "%d", &k);
+
+  char transA = 'N';
+  if (argc >= 5)
+    sscanf(argv[4], "%c", &transA);
+
+  char transB = 'T';
+  if (argc >= 6)
+    sscanf(argv[5], "%c", &transB);
+
+  using TA = float;
+  using TB = float;
+  using TC = float;
+  using TI = float;
+
+  TI alpha = 1.0;
+  TI beta  = 0.0;
+
+  std::cout << "M = " << m << std::endl;
+  std::cout << "N = " << n << std::endl;
+  std::cout << "K = " << k << std::endl;
+  std::cout << "C = A^" << transA << " B^" << transB << std::endl;
+
+  std::vector<TA> h_A(m*k);
+  std::vector<TB> h_B(n*k);
+  std::vector<TC> h_C(m*n);
+
+  for (int j = 0; j < m*k; ++j) h_A[j] = static_cast<TA>( 2*(rand() / double(RAND_MAX)) - 1 );
+  for (int j = 0; j < n*k; ++j) h_B[j] = static_cast<TB>( 2*(rand() / double(RAND_MAX)) - 1 );
+  for (int j = 0; j < m*n; ++j) h_C[j] = static_cast<TC>(-1);
+
+  auto d_A = syclcompat::malloc<TA>(m*k);
+  auto d_B = syclcompat::malloc<TB>(k*n);
+  auto d_C = syclcompat::malloc<TC>(m*n);
+
+  syclcompat::memcpy<TA>(d_A, h_A.data(), m*k);
+  syclcompat::memcpy<TB>(d_B, h_B.data(), k*n);
+  syclcompat::memcpy<TC>(d_C, h_C.data(), m*n);
+
+  double gflops = (2.0*m*n*k) * 1e-9;
+
+  const int timing_iterations = 100;
+  GPU_Clock timer;
+
+  int ldA = 0, ldB = 0, ldC = m;
+
+  if (transA == 'N') {
+    ldA = m;
+  } else if (transA == 'T') {
+    ldA = k;
+  } else {
+    assert(false);
+  }
+
+  if (transB == 'N') {
+    ldB = k;
+  } else if (transB == 'T') {
+    ldB = n;
+  } else {
+    assert(false);
+  }
+
+  // Run once
+  gemm(transA, transB, m, n, k,
+       alpha,
+       d_A, ldA,
+       d_B, ldB,
+       beta,
+       d_C, ldC);
+  syclcompat::wait_and_throw();
+
+  // Timing iterations
+  timer.start();
+  for (int i = 0; i < timing_iterations; ++i) {
+    gemm(transA, transB, m, n, k,
+         alpha,
+         d_A, ldA,
+         d_B, ldB,
+         beta,
+         d_C, ldC);
+  }
+  double cute_time = timer.seconds() / timing_iterations;
+  printf("CUTE_GEMM:     [%6.1f]GFlop/s  (%6.4f)ms\n", gflops / cute_time, cute_time*1000);
+
+  return 0;
+}

--- a/examples/cute/tutorial/tiled_copy_sycl.cpp
+++ b/examples/cute/tutorial/tiled_copy_sycl.cpp
@@ -1,0 +1,249 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2024 Codeplay Software Ltd. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+#include <syclcompat.hpp>
+
+#include <cute/tensor.hpp>
+
+#include "cutlass/util/print_error.hpp"
+
+// This is a simple tutorial showing several ways to partition a tensor into tiles then
+// perform efficient, coalesced copies. This example also shows how to vectorize accesses
+// which may be a useful optimization or required for certain workloads.
+//
+// `copy_kernel()` and `copy_kernel_vectorized()` each assume a pair of tensors with
+// dimensions (m, n) have been partitioned via `tiled_divide()`.
+//
+// The result are a part of compatible tensors with dimensions ((M, N), m', n'), where
+// (M, N) denotes a statically sized tile, and m' and n' denote the number of such tiles
+// within the tensor.
+//
+// Each statically sized tile is mapped to a CUDA threadblock which performs efficient
+// loads and stores to Global Memory.
+//
+// `copy_kernel()` uses `cute::local_partition()` to partition the tensor and map
+// the result to threads using a striped indexing scheme. Threads themselve are arranged
+// in a (ThreadShape_M, ThreadShape_N) arrangement which is replicated over the tile.
+//
+// `copy_kernel_vectorized()` uses `cute::make_tiled_copy()` to perform a similar
+// partitioning using `cute::Copy_Atom` to perform vectorization. The actual vector
+// size is defined by `ThreadShape`.
+//
+// This example assumes the overall tensor shape is divisible by the tile size and
+// does not perform predication.
+
+
+/// Simple copy kernel.
+//
+// Uses local_partition() to partition a tile among threads arranged as (THR_M, THR_N).
+template <class TensorS, class TensorD, class ThreadLayout>
+void copy_kernel(TensorS S, TensorD D, ThreadLayout)
+{
+  using namespace cute;
+
+  // Slice the tiled tensors
+  Tensor tile_S = S(make_coord(_,_), syclcompat::work_group_id::x(),
+                    syclcompat::work_group_id::y());            // (BlockShape_M, BlockShape_N)
+  Tensor tile_D = D(make_coord(_,_), syclcompat::work_group_id::x(),
+                    syclcompat::work_group_id::y());            // (BlockShape_M, BlockShape_N)
+
+  // Construct a partitioning of the tile among threads with the given thread arrangement.
+
+  // Concept:                         Tensor  ThrLayout       ThrIndex
+  Tensor thr_tile_S = local_partition(tile_S, ThreadLayout{}, syclcompat::local_id::x());  // (ThrValM, ThrValN)
+  Tensor thr_tile_D = local_partition(tile_D, ThreadLayout{}, syclcompat::local_id::x());  // (ThrValM, ThrValN)
+
+  // Construct a register-backed Tensor with the same shape as each thread's partition
+  // Use make_tensor to try to match the layout of thr_tile_S
+  Tensor fragment = make_tensor_like(thr_tile_S);               // (ThrValM, ThrValN)
+
+  // Copy from GMEM to RMEM and from RMEM to GMEM
+  copy(thr_tile_S, fragment);
+  copy(fragment, thr_tile_D);
+}
+
+/// Vectorized copy kernel.
+///
+/// Uses `make_tiled_copy()` to perform a copy using vector instructions. This operation
+/// has the precondition that pointers are aligned to the vector size.
+///
+template <class TensorS, class TensorD, class ThreadLayout, class VecLayout>
+void copy_kernel_vectorized(TensorS S, TensorD D, ThreadLayout, VecLayout)
+{
+  using namespace cute;
+
+  using Element = typename TensorS::value_type;
+
+  // Slice the tensors to obtain a view into each tile.
+  Tensor tile_S = S(make_coord(_, _), syclcompat::work_group_id::x(),
+                    syclcompat::work_group_id::y());  // (BlockShape_M, BlockShape_N)
+  Tensor tile_D = D(make_coord(_, _), syclcompat::work_group_id::x(),
+                    syclcompat::work_group_id::y());  // (BlockShape_M, BlockShape_N)
+
+  // Define `AccessType` which controls the size of the actual memory access.
+  using AccessType = cutlass::AlignedArray<Element, size(VecLayout{})>;
+
+  // A copy atom corresponds to one hardware memory access.
+  using Atom = Copy_Atom<UniversalCopy<AccessType>, Element>;
+
+  // Construct tiled copy, a tiling of copy atoms.
+  //
+  // Note, this assumes the vector and thread layouts are aligned with contigous data
+  // in GMEM. Alternative thread layouts are possible but may result in uncoalesced
+  // reads. Alternative vector layouts are also possible, though incompatible layouts
+  // will result in compile time errors.
+  auto tiled_copy =
+    make_tiled_copy(
+      Atom{},                       // access size
+      ThreadLayout{},               // thread layout
+      VecLayout{});                 // vector layout (e.g. 4x1)
+
+  // Construct a Tensor corresponding to each thread's slice.
+  auto thr_copy = tiled_copy.get_thread_slice(syclcompat::local_id::x());
+
+  Tensor thr_tile_S = thr_copy.partition_S(tile_S);             // (CopyOp, CopyM, CopyN)
+  Tensor thr_tile_D = thr_copy.partition_D(tile_D);             // (CopyOp, CopyM, CopyN)
+
+  // Construct a register-backed Tensor with the same shape as each thread's partition
+  // Use make_fragment because the first mode is the instruction-local mode
+  Tensor fragment = make_fragment_like(thr_tile_D);             // (CopyOp, CopyM, CopyN)
+
+  // Copy from GMEM to RMEM and from RMEM to GMEM
+  copy(tiled_copy, thr_tile_S, fragment);
+  copy(tiled_copy, fragment, thr_tile_D);
+}
+
+/// Main function
+int main(int argc, char** argv)
+{
+  //
+  // Given a 2D shape, perform an efficient copy
+  //
+
+  using namespace cute;
+  using Element = float;
+
+  // Define a tensor shape with dynamic extents (m, n)
+  auto tensor_shape = make_shape(256, 512);
+
+  //
+  // Allocate and initialize
+  //
+  std::vector<Element> h_S(size(tensor_shape));
+  std::vector<Element> h_D(size(tensor_shape));
+
+  auto d_S = syclcompat::malloc<Element>(size(tensor_shape));
+  auto d_D = syclcompat::malloc<Element>(size(tensor_shape));
+
+  for (size_t i = 0; i < h_S.size(); ++i) {
+    h_S[i] = static_cast<Element>(i);
+  }
+
+  syclcompat::memcpy<Element>(d_S, h_S.data(), size(tensor_shape));
+  syclcompat::memcpy<Element>(d_D, h_D.data(), size(tensor_shape));
+
+  //
+  // Make tensors
+  //
+
+  Tensor tensor_S = make_tensor(d_S, make_layout(tensor_shape));
+  Tensor tensor_D = make_tensor(d_D, make_layout(tensor_shape));
+
+  //
+  // Tile tensors
+  //
+
+  // Define a statically sized block (M, N).
+  // Note, by convention, capital letters are used to represent static modes.
+  auto block_shape = make_shape(Int<128>{}, Int<64>{});
+
+  if ((size<0>(tensor_shape) % size<0>(block_shape)) || (size<1>(tensor_shape) % size<1>(block_shape))) {
+    std::cerr << "The tensor shape must be divisible by the block shape." << std::endl;
+    return -1;
+  }
+  // Equivalent check to the above
+  if (not weakly_compatible(block_shape, tensor_shape)) {
+    std::cerr << "Expected the tensors to be weakly compatible with the block_shape." << std::endl;
+    return -1;
+  }
+
+  // Tile the tensor (m, n) ==> ((M, N), m', n') where (M, N) is the static tile
+  // shape, and modes (m', n') correspond to the number of tiles.
+  //
+  // These will be used to determine the CUDA kernel grid dimensions.
+  Tensor tiled_tensor_S = tiled_divide(tensor_S, block_shape);      // ((M, N), m', n')
+  Tensor tiled_tensor_D = tiled_divide(tensor_D, block_shape);      // ((M, N), m', n')
+
+  // Thread arrangement
+  Layout thr_layout = make_layout(make_shape(Int<32>{}, Int<8>{}));
+
+  // Vector dimensions
+  Layout vec_layout = make_layout(make_shape(Int<4>{}, Int<1>{}));
+
+  //
+  // Determine grid and block dimensions
+  //
+
+  auto gridDim  = syclcompat::dim3(size<1>(tiled_tensor_D), size<2>(tiled_tensor_D));  // Grid shape corresponds to modes m' and n'
+  auto blockDim = syclcompat::dim3(size(thr_layout));
+
+  //
+  // Launch the kernel
+  //
+  syclcompat::launch<copy_kernel_vectorized<decltype(tiled_tensor_S), decltype(tiled_tensor_D),
+                                            decltype(thr_layout), decltype(vec_layout)>>(
+      gridDim, blockDim, tiled_tensor_S, tiled_tensor_D, thr_layout, vec_layout);
+  syclcompat::wait_and_throw();
+
+  //
+  // Verify
+  //
+
+  syclcompat::memcpy<Element>(h_D.data(), d_D, size(tensor_shape));
+
+  int32_t errors = 0;
+  int32_t const kErrorLimit = 10;
+
+  for (size_t i = 0; i < h_D.size(); ++i) {
+    if (h_S[i] != h_D[i]) {
+      std::cerr << "Error. S[" << i << "]: " << h_S[i] << ",   D[" << i << "]: " << h_D[i] << std::endl;
+
+      if (++errors >= kErrorLimit) {
+        std::cerr << "Aborting on " << kErrorLimit << "nth error." << std::endl;
+        return -1;
+      }
+    }
+  }
+
+  std::cout << "Success." << std::endl;
+
+  return 0;
+}

--- a/include/cute/arch/copy.hpp
+++ b/include/cute/arch/copy.hpp
@@ -97,7 +97,7 @@ using DefaultCopy = AutoVectorizingCopy;
 CUTE_HOST_DEVICE static void
 prefetch(void const* gmem_ptr)
 {
-#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
   asm volatile("prefetch.global.L2 [%0];\n" : : "l"(gmem_ptr) : "memory");
 #endif
 }

--- a/include/cute/arch/copy_sm80.hpp
+++ b/include/cute/arch/copy_sm80.hpp
@@ -35,7 +35,8 @@
 #include <cute/arch/copy.hpp>
 
 // Config
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800))
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)) || \
+    (defined(__SYCL_CUDA_ARCH__) && (__SYCL_CUDA_ARCH__ >= 800))
 #  define CUTE_ARCH_CP_ASYNC_SM80_ENABLED
 #endif
 

--- a/include/cute/arch/copy_sm90_desc.hpp
+++ b/include/cute/arch/copy_sm90_desc.hpp
@@ -30,7 +30,7 @@
  **************************************************************************************************/
 #pragma once
 
-#if !defined(__CUDACC_RTC__)
+#if !defined(__CUDACC_RTC__) && !defined(CUTLASS_ENABLE_SYCL)
 #include <cuda.h>
 #include <cinttypes>
 #endif

--- a/include/cute/arch/mma_sm61.hpp
+++ b/include/cute/arch/mma_sm61.hpp
@@ -35,7 +35,8 @@
 #include <cute/arch/mma.hpp>
 
 // Config
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 610))
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 610)) || \
+    (defined(__SYCL_CUDA_ARCH) && (__SYCL_CUDA_ARCH__ >= 610))
 #  define CUTE_ARCH_MMA_SM61_ENABLED
 #endif
 

--- a/include/cute/arch/mma_sm70.hpp
+++ b/include/cute/arch/mma_sm70.hpp
@@ -37,7 +37,8 @@
 // Config
 #if ((__CUDACC_VER_MAJOR__ > 10) || (__CUDACC_VER_MAJOR__ == 10 && __CUDACC_VER_MINOR__ >= 1))
 #  define CUTE_ARCH_MMA_SM70_SUPPORTED
-#  if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 700))
+#  if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 700)) || \
+      (defined(__SYCL_CUDA_ARCH__) && (__SYCL_CUDA_ARCH__ >= 700))
 #    define CUTE_ARCH_MMA_SM70_ENABLED
 #  endif
 #endif

--- a/include/cute/arch/mma_sm75.hpp
+++ b/include/cute/arch/mma_sm75.hpp
@@ -37,7 +37,8 @@
 // Config
 #if ((__CUDACC_VER_MAJOR__ > 10) || (__CUDACC_VER_MAJOR__ == 10 && __CUDACC_VER_MINOR__ >= 2))
 #  define CUTE_ARCH_MMA_SM75_SUPPORTED
-#  if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 750))
+#  if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 750)) || \
+      (defined(__SYCL_CUDA_ARCH__) && (__SYCL_CUDA_ARCH__ >= 750))
 #    define CUTE_ARCH_MMA_SM75_ENABLED
 #  endif
 #endif

--- a/include/cute/arch/mma_sm80.hpp
+++ b/include/cute/arch/mma_sm80.hpp
@@ -36,14 +36,15 @@
 #include <cute/numeric/complex.hpp>
 
 // Config
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800))
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)) || \
+    (defined(__SYCL_CUDA_ARCH__) && (__SYCL_CUDA_ARCH__ >= 800))
 #  define CUTE_ARCH_MMA_SM80_ENABLED
 
-#if (__CUDA_ARCH__ <= 900)
+#if (__CUDA_ARCH__ <= 900 || __SYCL_CUDA_ARCH__ <= 900)
 #define CUTE_ARCH_MMA_B1_AND_SM80_ENABLED
 #endif
 
-#if (__CUDA_ARCH__ <= 890)
+#if (__CUDA_ARCH__ <= 890 || __SYCL_CUDA_ARCH__ <= 890)
 #define CUTE_ARCH_MMA_B1_XOR_SM80_ENABLED
 #endif
 

--- a/include/cute/arch/util.hpp
+++ b/include/cute/arch/util.hpp
@@ -112,6 +112,10 @@ cast_smem_ptr_to_uint(void const* const ptr)
 
   return __nvvm_get_smem_pointer(ptr);
 
+#elif defined(CUTLASS_ENABLE_SYCL)
+
+  return (intptr_t)(sycl::decorated_local_ptr<const void>::pointer)ptr;
+
 #elif defined(__CUDA_ARCH__)
 
   uint32_t smem_ptr;
@@ -253,6 +257,93 @@ explode(Fn fn,
 {
   return fn(d[Id]..., a[Ia]..., b[Ib]..., c[Ic]..., sfa[Isfa]..., sfb[Isfb]...);
 }
+
+#if defined(CUTLASS_ENABLE_SYCL)
+template <class MMA_Op,
+          class PtrA, int... I>
+CUTE_HOST_DEVICE constexpr
+void
+explode_mma(PtrA&& a, int_sequence<I...>)
+{
+  return MMA_Op::fma(a[I]...);
+}
+
+template <class MMA_Op,
+          class PtrS, int... Is,
+          class PtrD, int... Id>
+CUTE_HOST_DEVICE constexpr
+void
+explode_mma(PtrS&& s, int_sequence<Is...>,
+            PtrD&& d, int_sequence<Id...>)
+{
+  return MMA_Op::fma(s[Is]..., d[Id]...);
+}
+
+template <class MMA_Op,
+          class PtrA, int... Ia,
+          class PtrB, int... Ib,
+          class PtrC, int... Ic>
+CUTE_HOST_DEVICE constexpr
+void
+explode_mma(PtrA&& a, int_sequence<Ia...>,
+            PtrB&& b, int_sequence<Ib...>,
+            PtrC&& c, int_sequence<Ic...>)
+{
+  return MMA_Op::fma(a[Ia]..., b[Ib]..., c[Ic]...);
+}
+
+template <class MMA_Op,
+          class PtrD, int... Id,
+          class PtrA, int... Ia,
+          class PtrB, int... Ib,
+          class PtrC, int... Ic>
+CUTE_HOST_DEVICE constexpr
+void
+explode_mma(PtrD&& d, int_sequence<Id...>,
+            PtrA&& a, int_sequence<Ia...>,
+            PtrB&& b, int_sequence<Ib...>,
+            PtrC&& c, int_sequence<Ic...>)
+{
+  return MMA_Op::fma(d[Id]..., a[Ia]..., b[Ib]..., c[Ic]...);
+}
+
+template <class MMA_Op,
+          class PtrD, int... Id,
+          class PtrA, int... Ia,
+          class PtrB, int... Ib,
+          class PtrC, int... Ic,
+          class PtrE, int... Ie>
+CUTE_HOST_DEVICE constexpr
+void
+explode_mma(PtrD&& d, int_sequence<Id...>,
+            PtrA&& a, int_sequence<Ia...>,
+            PtrB&& b, int_sequence<Ib...>,
+            PtrC&& c, int_sequence<Ic...>,
+            PtrE&& e, int_sequence<Ie...>)
+{
+  return MMA_Op::fma(d[Id]..., a[Ia]..., b[Ib]..., c[Ic]..., e[Ie]...);
+}
+
+template <class MMA_Op,
+          class PtrD,   int... Id,
+          class PtrA,   int... Ia,
+          class PtrB,   int... Ib,
+          class PtrC,   int... Ic,
+          class PtrSFA, int... Isfa,
+          class PtrSFB, int... Isfb>
+CUTE_HOST_DEVICE constexpr
+void
+explode_mma(PtrD&& d,     int_sequence<Id...>,
+            PtrA&& a,     int_sequence<Ia...>,
+            PtrB&& b,     int_sequence<Ib...>,
+            PtrC&& c,     int_sequence<Ic...>,
+            PtrSFA&& sfa, int_sequence<Isfa...>,
+            PtrSFB&& sfb, int_sequence<Isfb...>)
+{
+  return MMA_Op::fma(d[Id]..., a[Ia]..., b[Ib]..., c[Ic]..., sfa[Isfa]..., sfb[Isfb]...);
+}
+#endif
+
 //
 // Utility for exploding tuples into functions
 //

--- a/include/cute/atom/copy_traits_sm90_tma.hpp
+++ b/include/cute/atom/copy_traits_sm90_tma.hpp
@@ -30,7 +30,7 @@
  **************************************************************************************************/
 #pragma once
 
-#if !defined(__CUDACC_RTC__)
+#if !defined(__CUDACC_RTC__) && !defined(CUTLASS_ENABLE_SYCL)
 #include <cuda.h>
 #endif
 

--- a/include/cute/atom/copy_traits_sm90_tma_swizzle.hpp
+++ b/include/cute/atom/copy_traits_sm90_tma_swizzle.hpp
@@ -33,7 +33,7 @@
 /// @file copy_traits_sm90_tma_swizzle.hpp
 /// @brief Functions for converting swizzle layout to TMA descriptor
 
-#if !defined(__CUDACC_RTC__)
+#if !defined(__CUDACC_RTC__) && !defined(CUTLASS_ENABLE_SYCL)
 #include <cuda.h>
 #endif
 

--- a/include/cute/atom/mma_traits.hpp
+++ b/include/cute/atom/mma_traits.hpp
@@ -149,17 +149,30 @@ mma_unpack(MMA_Traits<MMA_Op, MMA_Args...> const& traits,
     //CUTE_STATIC_ASSERT_V(size(rC) == Int<RegNumC>{});
 
     if constexpr (detail::supports_output_scaling<MMATraits>::value) {
+#if defined(CUTLASS_ENABLE_SYCL)
+      detail::explode_mma<MMA_Op>(rA, make_int_sequence<RegNumA>{},
+                                  rB, make_int_sequence<RegNumB>{},
+                                  rC, make_int_sequence<RegNumC>{},
+                                  &(traits.accumulate_), seq<0>{});
+#else
       detail::explode(MMA_Op::fma,
                       rA, make_int_sequence<RegNumA>{},
                       rB, make_int_sequence<RegNumB>{},
                       rC, make_int_sequence<RegNumC>{},
                       &(traits.accumulate_), seq<0>{});
+#endif
     }
     else {
+#if defined(CUTLASS_ENABLE_SYCL)
+      detail::explode_mma<MMA_Op>(rA, make_int_sequence<RegNumA>{},
+                                  rB, make_int_sequence<RegNumB>{},
+                                  rC, make_int_sequence<RegNumC>{});
+#else
       detail::explode(MMA_Op::fma,
                       rA, make_int_sequence<RegNumA>{},
                       rB, make_int_sequence<RegNumB>{},
                       rC, make_int_sequence<RegNumC>{});
+#endif
     }
   }
   else {
@@ -169,19 +182,34 @@ mma_unpack(MMA_Traits<MMA_Op, MMA_Args...> const& traits,
       CUTE_STATIC_ASSERT_V(size(rD) == Int<RegNumD>{});
       CUTE_STATIC_ASSERT_V(size(rC) == Int<RegNumC>{});
       if constexpr (detail::supports_output_scaling<MMATraits>::value) {
+#if defined(CUTLASS_ENABLE_SYCL)
+        detail::explode_mma<MMA_Op>(rD, make_int_sequence<RegNumD>{},
+                                    rA, make_int_sequence<RegNumA>{},
+                                    rB, make_int_sequence<RegNumB>{},
+                                    rC, make_int_sequence<RegNumC>{},
+                                    &(traits.accumulate_), seq<0>{});
+#else
         detail::explode(MMA_Op::fma,
                         rD, make_int_sequence<RegNumD>{},
                         rA, make_int_sequence<RegNumA>{},
                         rB, make_int_sequence<RegNumB>{},
                         rC, make_int_sequence<RegNumC>{},
                         &(traits.accumulate_), seq<0>{});
+#endif
       }
       else {
+#if defined(CUTLASS_ENABLE_SYCL)
+        detail::explode_mma<MMA_Op>(rD, make_int_sequence<RegNumD>{},
+                                    rA, make_int_sequence<RegNumA>{},
+                                    rB, make_int_sequence<RegNumB>{},
+                                    rC, make_int_sequence<RegNumC>{});
+#else
         detail::explode(MMA_Op::fma,
                         rD, make_int_sequence<RegNumD>{},
                         rA, make_int_sequence<RegNumA>{},
                         rB, make_int_sequence<RegNumB>{},
                         rC, make_int_sequence<RegNumC>{});
+#endif
       }
   }
 }

--- a/include/cute/config.hpp
+++ b/include/cute/config.hpp
@@ -34,6 +34,10 @@
 #  define CUTE_HOST_DEVICE __forceinline__ __host__ __device__
 #  define CUTE_DEVICE      __forceinline__          __device__
 #  define CUTE_HOST        __forceinline__ __host__
+#elif defined(__SYCL_DEVICE_ONLY__)
+#  define CUTE_HOST_DEVICE __attribute__((always_inline)) inline
+#  define CUTE_DEVICE      __attribute__((always_inline)) inline
+#  define CUTE_HOST        inline
 #else
 #  define CUTE_HOST_DEVICE inline
 #  define CUTE_DEVICE      inline

--- a/include/cute/container/tuple.hpp
+++ b/include/cute/container/tuple.hpp
@@ -35,8 +35,9 @@
 #include <cute/numeric/integral_constant.hpp>  // cute::true_type, cute::false_type
 #include <cute/numeric/integer_sequence.hpp>
 
+#if !defined(CUTLASS_ENABLE_SYCL)
 #include <cute/container/cuda_types.hpp>
-
+#endif
 //#include <cute/container/array.hpp>            // Advanced optimizations
 
 //

--- a/include/cute/numeric/numeric_types.hpp
+++ b/include/cute/numeric/numeric_types.hpp
@@ -30,7 +30,11 @@
  **************************************************************************************************/
 #pragma once
 
+#if defined(CUTLASS_ENABLE_SYCL)
+#include <cutlass/sycl_vector_types.h>
+#else
 #include <vector_types.h>
+#endif
 #include <cutlass/numeric_types.h>
 #include <cutlass/numeric_size.h>
 

--- a/include/cute/util/print.hpp
+++ b/include/cute/util/print.hpp
@@ -34,6 +34,10 @@
 
 #include <cute/util/type_traits.hpp>
 
+#if defined(CUTLASS_ENABLE_SYCL)
+#define printf sycl::ext::oneapi::experimental::printf
+#endif
+
 //
 // CUDA compatible print and printf
 //

--- a/include/cutlass/bfloat16.h
+++ b/include/cutlass/bfloat16.h
@@ -45,7 +45,10 @@
 #include <cstring>
 #endif
 
+#if !defined(CUTLASS_ENABLE_SYCL)
 #include <cuda_bf16.h>
+#endif
+
 #include "cutlass/cutlass.h"
 #include "cutlass/platform/platform.h"
 
@@ -107,6 +110,10 @@ public:
     #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800) && (__CUDACC_VER_MAJOR__ >= 11)
 
     asm("cvt.rn.bf16.f32 %0, %1;\n" : "=h"(storage) : "f"(x));
+
+    #elif defined(CUTLASS_ENABLE_SYCL)
+
+    storage = sycl::ext::oneapi::detail::bfloat16ToBits(sycl::ext::oneapi::bfloat16(x));
 
     #else
     uint32_t bits;

--- a/include/cutlass/complex.h
+++ b/include/cutlass/complex.h
@@ -31,9 +31,13 @@
 
 #pragma once
 
+#if defined(CUTLASS_ENABLE_SYCL)
+#include <cutlass/sycl_complex.h>
+#include <cutlass/sycl_fp16.h>
+#else
 #include <cuComplex.h>
-
 #include <cuda_fp16.h>
+#endif
 
 #if defined(__CUDACC_RTC__)
 #include <cuda/std/cstdint>
@@ -85,7 +89,7 @@ struct InvertComplexTransform<ComplexTransform::kConjugate> {
 // Accessors for CUDA complex types
 //
 
-#if !defined(__CUDACC_RTC__)
+#if !defined(__CUDACC_RTC__) && !defined(CUTLASS_ENABLE_SYCL)
 /// Returns the real part of the complex number
 CUTLASS_HOST_DEVICE
 float const &real(cuFloatComplex const &z) { return z.x; }

--- a/include/cutlass/float8.h
+++ b/include/cutlass/float8.h
@@ -74,10 +74,14 @@
 #include <cstring>
 #endif
 
+#if !defined(CUTLASS_ENABLE_SYCL)
 #ifdef CUDA_FP8_ENABLED
 #include <cuda_fp8.h>
 #endif
 #include <cuda_fp16.h>
+#else
+#include <cutlass/sycl_fp16.h>
+#endif
 
 #include "cutlass/cutlass.h"
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -412,6 +416,8 @@ struct alignas(1) float_e4m3_t : float8_base<FloatEncoding::E4M3> {
         asm volatile("cvt.rn.satfinite.e4m3x2.f16x2 %0, %1;" : "=h"(tmp) : "r"(bits));
 
         return *reinterpret_cast<float_e4m3_t *>(&tmp);
+    #elif defined(CUTLASS_ENABLE_SYCL)
+        return bitcast(Base::convert_float_to_fp8(flt));
     #else
         return bitcast(Base::convert_float_to_fp8(__half2float(flt)));
     #endif
@@ -426,6 +432,8 @@ struct alignas(1) float_e4m3_t : float8_base<FloatEncoding::E4M3> {
         asm volatile("cvt.rn.f16x2.e4m3x2 %0, %1;\n" : "=r"(packed) : "h"(bits));
 
         return reinterpret_cast<half2 const &>(packed).x;
+    #elif defined(CUTLASS_ENABLE_SYCL)
+        return Base::convert_fp8_to_float(x.storage);
     #else
         return __float2half(Base::convert_fp8_to_float(x.storage));
     #endif
@@ -621,6 +629,8 @@ struct alignas(1) float_e5m2_t : float8_base<FloatEncoding::E5M2> {
         asm volatile("cvt.rn.satfinite.e5m2x2.f16x2 %0, %1;" : "=h"(tmp) : "r"(bits));
 
         return *reinterpret_cast<float_e5m2_t *>(&tmp);
+    #elif defined(CUTLASS_ENABLE_SYCL)
+        return bitcast(Base::convert_float_to_fp8(flt));
     #else
         return bitcast(Base::convert_float_to_fp8(__half2float(flt)));
     #endif
@@ -635,6 +645,8 @@ struct alignas(1) float_e5m2_t : float8_base<FloatEncoding::E5M2> {
         asm volatile("cvt.rn.f16x2.e5m2x2 %0, %1;\n" : "=r"(packed) : "h"(bits));
 
         return reinterpret_cast<half2 const &>(packed).x;
+    #elif defined(CUTLASS_ENABLE_SYCL)
+        return Base::convert_fp8_to_float(x.storage);
     #else
         return __float2half(Base::convert_fp8_to_float(x.storage));
     #endif

--- a/include/cutlass/functional.h
+++ b/include/cutlass/functional.h
@@ -38,7 +38,9 @@
 #include "cutlass/cutlass.h"
 #include "cutlass/numeric_types.h"
 
+#if !defined(CUTLASS_ENABLE_SYCL)
 #include <cuda_runtime.h>
+#endif
 
 #if defined(CUTLASS_ARCH_WMMA_ENABLED)
 #include <mma.h>

--- a/include/cutlass/half.h
+++ b/include/cutlass/half.h
@@ -60,7 +60,9 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
+#if !defined(CUTLASS_ENABLE_SYCL)
 #include <cuda_fp16.h>
+#endif
 
 #include "cutlass/cutlass.h"
 #include "cutlass/float8.h"
@@ -195,6 +197,8 @@ struct alignas(2) half_t {
   static half_t convert(float const& flt) {
   #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 530)
     return half_t(__float2half_rn(flt));
+  #elif defined(CUTLASS_ENABLE_SYCL)
+    return static_cast<half_t>(flt);
   #else
 
     #if !defined(__CUDA_ARCH__) && CUTLASS_ENABLE_F16C
@@ -276,6 +280,8 @@ struct alignas(2) half_t {
   static half_t convert(int const& n) {
   #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 530)
     return half_t(__int2half_rn(n));
+  #elif defined(CUTLASS_ENABLE_SYCL)
+    return static_cast<half_t>(n);
   #else
     return convert(float(n));
   #endif
@@ -286,6 +292,8 @@ struct alignas(2) half_t {
   static half_t convert(unsigned const& n) {
   #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 530)
     return half_t(__uint2half_rn(n));
+  #elif defined(CUTLASS_ENABLE_SYCL)
+    return static_cast<half_t>(n);
   #else
     return convert(float(n));
   #endif
@@ -301,6 +309,8 @@ struct alignas(2) half_t {
   static float convert(half_t const& x) {
   #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 530)
     return __half2float(x.to_half());
+  #elif defined(CUTLASS_ENABLE_SYCL)
+    return x.to_half();
   #else
 
     #if !defined(__CUDA_ARCH__) && CUTLASS_ENABLE_F16C
@@ -361,7 +371,7 @@ struct alignas(2) half_t {
   /// Reinterpret cast from CUDA's half type
   CUTLASS_HOST_DEVICE
   explicit half_t(half const & x) {
-    #if defined(__CUDA_ARCH__)
+    #if defined(__CUDA_ARCH__) || defined(CUTLASS_ENABLE_SYCL)
     storage = reinterpret_cast<uint16_t const &>(x);
     #else
     __half_raw raw(x);
@@ -408,7 +418,7 @@ struct alignas(2) half_t {
   /// Assignment
   CUTLASS_HOST_DEVICE
   half_t & operator=(half const &x) {
-    #if defined(__CUDA_ARCH__)
+    #if defined(__CUDA_ARCH__) || defined(CUTLASS_ENABLE_SYCL)
     storage = reinterpret_cast<uint16_t const &>(x);
     #else
     __half_raw raw(x);
@@ -444,7 +454,7 @@ struct alignas(2) half_t {
   /// Bitcasts to CUDA's half type
   CUTLASS_HOST_DEVICE
   half to_half() const {
-    #if defined(__CUDA_ARCH__)
+    #if defined(__CUDA_ARCH__) || defined(CUTLASS_ENABLE_SYCL)
     return reinterpret_cast<half const &>(storage);
     #else
     __half_raw raw;

--- a/include/cutlass/platform/platform.h
+++ b/include/cutlass/platform/platform.h
@@ -123,7 +123,11 @@
 #include <type_traits>  // For integral constants, conditional metaprogramming, and type traits
 #endif
 
+#if defined(CUTLASS_ENABLE_SYCL)
+#include <cutlass/sycl_vector_types.h>
+#else
 #include <vector_types.h>
+#endif
 #include <cutlass/cutlass.h>
 
 #endif

--- a/include/cutlass/sycl_complex.h
+++ b/include/cutlass/sycl_complex.h
@@ -1,5 +1,5 @@
 /***************************************************************************************************
- * Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+* Copyright (c) 2024 - 2024 Codeplay Software Ltd. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,70 +28,36 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  **************************************************************************************************/
-
 #pragma once
 
-#if defined(CUTLASS_ENABLE_SYCL)
-#include "cutlass/util/sycl_event_manager.hpp"
-#else
-#include <cuda_runtime.h>
-#endif
+#include "cutlass/detail/helper_macros.hpp"
 
-struct GPU_Clock
-{
-  GPU_Clock() {
-#if defined(CUTLASS_ENABLE_SYCL)
-    start_ = SyclEvent{};
-    stop_ = SyclEvent{};
-#else
-    cudaEventCreate(&start_);
-    cudaEventCreate(&stop_);
-    cudaEventRecord(start_);
-#endif
-  }
+namespace cutlass {
+// Add these definitions in the cutlass namespace, so they do not clash with the ones in cuda
+using cuFloatComplex = std::complex<float>;
+using cuDoubleComplex = std::complex<double>;
 
-  ~GPU_Clock() {
-#if defined(CUTLASS_ENABLE_SYCL)
-    syclEventDestroy(start_);
-    syclEventDestroy(stop_);
-#else
-    cudaEventDestroy(start_);
-    cudaEventDestroy(stop_);
-#endif
-  }
+CUTLASS_HOST_DEVICE
+float cuCrealf(cuFloatComplex x) {
+  return x.real();
+}
 
-  void start() {
-#if defined(CUTLASS_ENABLE_SYCL)
-    syclEventRecord(start_);
-#else
-    cudaEventRecord(start_);
-#endif
-  }
+CUTLASS_HOST_DEVICE
+float cuCimagf(cuFloatComplex x) {
+  return x.imag();
+}
 
-  float milliseconds() {
-#if defined(CUTLASS_ENABLE_SYCL)
-    syclEventRecord(stop_);
-    syclEventSynchronize(start_, stop_);
-    float time;
-    syclEventElapsedTime(&time, start_, stop_);
-    return time;
-#else
-    cudaEventRecord(stop_);
-    cudaEventSynchronize(stop_);
-    float time;
-    cudaEventElapsedTime(&time, start_, stop_);
-    return time;
-#endif
-  }
+CUTLASS_HOST_DEVICE double cuCreal(cuDoubleComplex x) {
+  return x.real();
+}
 
-  float seconds() {
-    return milliseconds() * float(1e-3);
-  }
+CUTLASS_HOST_DEVICE double cuCimag(cuDoubleComplex x) {
+  return x.imag();
+}
 
- private:
-#if defined(CUTLASS_ENABLE_SYCL)
-    SyclEvent start_, stop_;
-#else
-    cudaEvent_t start_, stop_;
-#endif
-};
+CUTLASS_HOST_DEVICE
+cuFloatComplex make_cuFloatComplex(float r, float i) {
+  return cuFloatComplex{r, i};
+}
+
+} // cutlass namespace

--- a/include/cutlass/sycl_fp16.h
+++ b/include/cutlass/sycl_fp16.h
@@ -1,5 +1,5 @@
 /***************************************************************************************************
- * Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2024 Codeplay Software Ltd. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,70 +28,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  **************************************************************************************************/
-
 #pragma once
 
-#if defined(CUTLASS_ENABLE_SYCL)
-#include "cutlass/util/sycl_event_manager.hpp"
-#else
-#include <cuda_runtime.h>
-#endif
+#include <sycl/sycl.hpp>
 
-struct GPU_Clock
-{
-  GPU_Clock() {
-#if defined(CUTLASS_ENABLE_SYCL)
-    start_ = SyclEvent{};
-    stop_ = SyclEvent{};
-#else
-    cudaEventCreate(&start_);
-    cudaEventCreate(&stop_);
-    cudaEventRecord(start_);
-#endif
-  }
-
-  ~GPU_Clock() {
-#if defined(CUTLASS_ENABLE_SYCL)
-    syclEventDestroy(start_);
-    syclEventDestroy(stop_);
-#else
-    cudaEventDestroy(start_);
-    cudaEventDestroy(stop_);
-#endif
-  }
-
-  void start() {
-#if defined(CUTLASS_ENABLE_SYCL)
-    syclEventRecord(start_);
-#else
-    cudaEventRecord(start_);
-#endif
-  }
-
-  float milliseconds() {
-#if defined(CUTLASS_ENABLE_SYCL)
-    syclEventRecord(stop_);
-    syclEventSynchronize(start_, stop_);
-    float time;
-    syclEventElapsedTime(&time, start_, stop_);
-    return time;
-#else
-    cudaEventRecord(stop_);
-    cudaEventSynchronize(stop_);
-    float time;
-    cudaEventElapsedTime(&time, start_, stop_);
-    return time;
-#endif
-  }
-
-  float seconds() {
-    return milliseconds() * float(1e-3);
-  }
-
- private:
-#if defined(CUTLASS_ENABLE_SYCL)
-    SyclEvent start_, stop_;
-#else
-    cudaEvent_t start_, stop_;
-#endif
-};
+// Add these definitions in the cutlass namespace, so they do not clash with the ones in cuda
+namespace cutlass {
+using half = sycl::half;
+using half2 = sycl::half2;
+}

--- a/include/cutlass/sycl_vector_types.h
+++ b/include/cutlass/sycl_vector_types.h
@@ -1,5 +1,5 @@
 /***************************************************************************************************
- * Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2024 Codeplay Software Ltd. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,70 +28,74 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  **************************************************************************************************/
-
 #pragma once
 
-#if defined(CUTLASS_ENABLE_SYCL)
-#include "cutlass/util/sycl_event_manager.hpp"
-#else
-#include <cuda_runtime.h>
-#endif
+#include "cutlass/detail/helper_macros.hpp"
 
-struct GPU_Clock
-{
-  GPU_Clock() {
-#if defined(CUTLASS_ENABLE_SYCL)
-    start_ = SyclEvent{};
-    stop_ = SyclEvent{};
-#else
-    cudaEventCreate(&start_);
-    cudaEventCreate(&stop_);
-    cudaEventRecord(start_);
-#endif
-  }
-
-  ~GPU_Clock() {
-#if defined(CUTLASS_ENABLE_SYCL)
-    syclEventDestroy(start_);
-    syclEventDestroy(stop_);
-#else
-    cudaEventDestroy(start_);
-    cudaEventDestroy(stop_);
-#endif
-  }
-
-  void start() {
-#if defined(CUTLASS_ENABLE_SYCL)
-    syclEventRecord(start_);
-#else
-    cudaEventRecord(start_);
-#endif
-  }
-
-  float milliseconds() {
-#if defined(CUTLASS_ENABLE_SYCL)
-    syclEventRecord(stop_);
-    syclEventSynchronize(start_, stop_);
-    float time;
-    syclEventElapsedTime(&time, start_, stop_);
-    return time;
-#else
-    cudaEventRecord(stop_);
-    cudaEventSynchronize(stop_);
-    float time;
-    cudaEventElapsedTime(&time, start_, stop_);
-    return time;
-#endif
-  }
-
-  float seconds() {
-    return milliseconds() * float(1e-3);
-  }
-
- private:
-#if defined(CUTLASS_ENABLE_SYCL)
-    SyclEvent start_, stop_;
-#else
-    cudaEvent_t start_, stop_;
-#endif
+// Add these definitions in the cutlass namespace, so they do not clash with the ones in cuda
+namespace cutlass {
+// We use this struct instead of sycl::int2 because the sycl type requires x() to access x,
+// while the struct does not need the (). This prevents us from having to modify the Cutlass
+// implementation in all the places where these vector types are used.
+using int2 = struct alignas(8) {
+  int x, y;
 };
+
+using int4 = struct alignas(16) {
+  int x, y, z, w;
+};
+
+using uint2 = struct alignas(8) {
+  unsigned int x, y;
+};
+
+using uint4 = struct alignas(16) {
+  unsigned int x, y, z, w;
+};
+
+using float4 = struct alignas(16) {
+  float x, y, z, w;
+};
+
+using long4 = struct alignas(16) {
+  long int x, y, z, w;
+};
+
+using ulong4 = struct alignas(16) {
+  unsigned long int x, y, z, w;
+};
+
+using longlong2 = struct alignas(16) {
+  long long int x, y;
+};
+
+using ulonglong2 = struct alignas(16) {
+  unsigned long long int x, y;
+};
+
+using longlong4 = struct alignas(16) {
+  long long int x, y, z, w;
+};
+
+using ulonglong4 = struct alignas(16) {
+  unsigned long long int x, y, z, w;
+};
+
+using double2 = struct alignas(16) {
+  long long int x, y;
+};
+
+using double4 = struct alignas(16) {
+  long long int x, y, z, w;
+};
+
+CUTLASS_HOST_DEVICE
+int2 make_int2(int x, int y) {
+  return int2{x,y};
+}
+
+CUTLASS_HOST_DEVICE
+int4 make_int4(int x, int y, int z, int w) {
+  return int4 {x,y,z,w};
+}
+}

--- a/include/cutlass/uint128.h
+++ b/include/cutlass/uint128.h
@@ -47,7 +47,7 @@
 #include "cutlass/cutlass.h"
 
 /// Optionally enable GCC's built-in type
-#if (defined(__x86_64) || defined (__aarch64__)) && !(defined(__CUDA_ARCH__) && ((__CUDACC_VER_MAJOR__ <= 10) || ((__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ <= 4)))) && defined(__GNUC__)
+#if (defined(__x86_64) || defined (__aarch64__)) && !((defined(__CUDA_ARCH__) || defined(__SYCL_DEVICE_ONLY__)) && ((__CUDACC_VER_MAJOR__ <= 10) || ((__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ <= 4)))) && defined(__GNUC__)
 #define CUTLASS_UINT128_NATIVE
 #elif defined(_MSC_VER) && defined(_M_AMD64) && !(defined(__CUDA_ARCH__) && ((__CUDACC_VER_MAJOR__ <= 10) || ((__CUDACC_VER_MAJOR__ == 11) && (__CUDACC_VER_MINOR__ <= 4))))
 #define CUTLASS_INT128_ARITHMETIC
@@ -112,7 +112,7 @@ struct alignas(16) uint128_t
   CUTLASS_HOST_DEVICE
   static void exception()
   {
-#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
   asm volatile ("  brkpt;\n");
 #else
   // throw std::runtime_error("Not yet implemented.");

--- a/media/docs/build/building_with_sycl_support.md
+++ b/media/docs/build/building_with_sycl_support.md
@@ -1,0 +1,104 @@
+
+[README](../../../README.md#documentation) > **CUTLASS 3: Building with Clang as Host Compiler**
+
+# Building with SYCL Support
+
+Cutlass 3 can be built with SYCL using the DPC++ compiler, enabling Cutlass
+to support other SYCL-enabled devices. This enhancement allows for greater
+flexibility and compatibility with diverse computational environments.
+
+SYCL[1] is a royalty-free, cross-platform abstraction layer that enables
+code for heterogeneous and offload processors to be written with modern
+ISO C++. It provides APIs and abstractions to find devices and manage
+resources for GPUs.
+
+## Limitations
+
+Currently, it's only possible to build five examples in the Cute
+tutorial and a reduced number of Cute tests.
+
+### Cute Tutorial Examples Supported
+
+* `sgemm_1`, `sgemm_2` and `tiled_copy`: Generic examples that should run on any
+  SYCL-enabled device. Tested on Nvidia SM80 devices and Intel PVC
+  and Arc devices.
+* `sgemm_sm70`: Nvidia SM70 specific example.
+* `sgemm_sm80`: Nvidia SM80 specific example.
+
+## Software Prerequisites
+
+To build CUTLASS with SYCL support, you need the latest version of
+the DPC++ compiler. You can either use a recent
+[nightly build](https://github.com/intel/llvm/releases)
+(see the [Setup DPC++ Nightly Build](#setup-dpc-nightly-build) section)
+or build the compiler from source as described in the
+[oneAPI DPC++ guideline](https://github.com/intel/llvm/blob/sycl/sycl/doc/GetStartedGuide.md#build-dpc-toolchain-with-support-for-nvidia-cuda).
+
+If building for an Nvidia GPU, the CUDA Toolkit will be required
+(tested with version 12.4).
+
+CMake (at least version 3.18), Ninja, git, and Python
+(at least version 3.6) are also required.
+
+### Setup DPC++ Nightly Build
+
+To install the nightly build, download DPC++ from the
+[nightly build](https://github.com/intel/llvm/releases). The minimum version
+required is nightly 2024-07-19.
+
+```bash
+$ export DPCPP_HOME=/opt/intel/dpcpp-nightly
+$ mkdir -p $DPCPP_HOME
+$ cd $DPCPP_HOME
+$ wget https://github.com/intel/llvm/releases/download/nightly-2024-07-19/sycl_linux.tar.gz
+$ tar -zxvf sycl_linux.tar.gz
+$ export PATH=$DPCPP_HOME/bin:$PATH
+$ export LD_LIBRARY_PATH=$DPCPP_HOME/lib:$LD_LIBRARY_PATH
+$ export C_INCLUDE_PATH=$DPCPP_HOME/include:$C_INCLUDE_PATH
+$ export CPLUS_INCLUDE_PATH=$DPCPP_HOME/include:$CPLUS_INCLUDE_PATH
+$ export CC=clang
+$ export CXX=clang++
+```
+
+# Running CMake
+
+## Required CMake options
+
+The SYCL build requires specifying the following CMake options and
+environmental variables. Replace `<path-to-clang>` and `<path-to-clang++>`
+with the path to your clang and clang++ executables. You may use `clang`
+and `clang++` directly if they are in your `PATH`.
+
+```bash
+$ export CC=<path-to-clang>/clang
+$ export CXX=<path-to-clang++>/clang++
+```
+
+### CMake options for Nvidia devices
+
+* `DPCPP_SYCL_TARGET=nvptx64-nvidia-cuda` sets the triplet target for Nvidia GPUs.
+* `DPCPP_SYCL_ARCH=sm_80` sets the device architecture to SM_80.
+
+```bash
+$ cmake -G Ninja .. \
+    -DCUTLASS_ENABLE_SYCL=ON \
+    -DDPCPP_SYCL_TARGET=nvptx64-nvidia-cuda \
+    -DDPCPP_SYCL_ARCH=sm_80
+```
+
+Building Cutlass with SYCL support on Nvidia devices has been tested
+on an A100 device with `DPCPP_SYCL_ARCH=sm_80`.
+
+### CMake options for Intel devices
+
+* `DPCPP_SYCL_TARGET=intel_gpu_pvc` sets the triplet target for Intel PVC GPUs.
+
+```bash
+$ cmake -G Ninja .. \
+    -DCUTLASS_ENABLE_SYCL=ON \
+    -DDPCPP_SYCL_TARGET=intel_gpu_pvc
+```
+
+# References
+
+[1] https://www.khronos.org/sycl/

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -36,6 +36,10 @@ cutlass_add_library(
   common/filter_architecture.cpp
   )
 
+if (NOT CUTLASS_ENABLE_SYCL)
+  SET(ADD_CUDA ON)
+endif()
+
 target_link_libraries(
   cutlass_test_unit_infra
   PUBLIC
@@ -43,9 +47,13 @@ target_link_libraries(
   cutlass_tools_util_includes
   $<$<BOOL:${CUTLASS_ENABLE_CUBLAS}>:nvidia::cublas>
   GTest::gtest
-  cudart
-  cuda_driver
+  $<$<BOOL:${ADD_CUDA}>:nvidia::cudart>
+  $<$<BOOL:${ADD_CUDA}>:nvidia::cuda_driver>
   )
+
+if(CUTLASS_ENABLE_SYCL)
+  add_sycl_include_directories_to_target(cutlass_test_unit_infra)
+endif()
 
 cutlass_add_library(
   cutlass_test_unit_infra_lib
@@ -99,6 +107,10 @@ function(cutlass_test_unit_add_executable NAME)
     target_link_libraries(${NAME} PRIVATE OpenMP::OpenMP_CXX)
   endif()
 
+  if(CUTLASS_ENABLE_SYCL)
+    add_sycl_to_target(TARGET ${NAME})
+  endif()
+
   string(REGEX REPLACE cutlass_ "" NAME_STEM ${NAME})
 
   set(RESULT_CACHE_FILE "${CUTLASS_TEST_UNIT_RESULTS_CACHE_DIR}/cached_results_${NAME}.txt")
@@ -120,21 +132,26 @@ endfunction()
 add_custom_target(cutlass_test_unit)
 add_custom_target(test_unit)
 
-set(SUBDIRS
-  core
-  cute
-  gemm
-  conv
-  layout
-  transform
-  epilogue
-  reduction
-  util
-  pipeline
-  substrate
-  cluster_launch
+if (CUTLASS_ENABLE_SYCL)
+  set(SUBDIRS
+    cute
   )
-
+else()
+  set(SUBDIRS
+    core
+    cute
+    gemm
+    conv
+    layout
+    transform
+    epilogue
+    reduction
+    util
+    pipeline
+    substrate
+    cluster_launch
+    )
+endif()
 if(TARGET nvidia::nvrtc AND TARGET nvidia::cuda_driver)
   set(CUTLASS_NVRTC_ENABLE_INIT ON)
 else()
@@ -143,7 +160,7 @@ endif()
 
 set(CUTLASS_NVRTC_ENABLE ${CUTLASS_NVRTC_ENABLE_INIT} CACHE BOOL "Enable NVRTC support")
 
-if (CUTLASS_NVRTC_ENABLE)
+if (CUTLASS_NVRTC_ENABLE AND NOT CUTLASS_ENABLE_SYCL)
   list(APPEND SUBDIRS nvrtc)
 endif()
 

--- a/test/unit/common/cutlass_unit_test.h
+++ b/test/unit/common/cutlass_unit_test.h
@@ -40,15 +40,19 @@
 #include <cstdlib>
 #include <string>
 
+#if !defined(CUTLASS_ENABLE_SYCL)
 #include <cuda_runtime_api.h>
+#endif
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
+#if !defined(CUTLASS_ENABLE_SYCL)
 /// Gets a CUDA device
 cudaDeviceProp GetCudaDevice();
 
 /// Prints device properties
 std::ostream &operator<<(std::ostream &out, cudaDeviceProp const &device);
+#endif
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/test/unit/common/filter_architecture.cpp
+++ b/test/unit/common/filter_architecture.cpp
@@ -29,9 +29,13 @@
  *
  **************************************************************************************************/
 
+#if !defined(CUTLASS_ENABLE_SYCL)
 #include <cuda_runtime_api.h>
+#endif
 
 #include "cutlass_unit_test.h"
+
+#if !defined(CUTLASS_ENABLE_SYCL)
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -70,10 +74,14 @@ std::ostream &operator<<(std::ostream &out, cudaDeviceProp const &deviceProperti
 
   return out;
 }
+
+#endif
+
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// Sets flags for Unit test
 void FilterArchitecture() {
+#if !defined(CUTLASS_ENABLE_SYCL)
   // Default flags can be overwritten by --gtest_filter from commandline
 
   int const kMaxDevice = 999;
@@ -136,6 +144,7 @@ void FilterArchitecture() {
   }
 
   ::testing::GTEST_FLAG(filter) = ss.str();
+#endif
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/test/unit/cute/CMakeLists.txt
+++ b/test/unit/cute/CMakeLists.txt
@@ -26,34 +26,50 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-add_subdirectory(core)
-add_subdirectory(volta)
-add_subdirectory(turing)
-add_subdirectory(ampere)
-add_subdirectory(hopper)
-add_subdirectory(layout)
-add_subdirectory(msvc_compilation)
+if (NOT CUTLASS_ENABLE_SYCL)
+  add_subdirectory(core)
+  add_subdirectory(volta)
+  add_subdirectory(turing)
+  add_subdirectory(ampere)
+  add_subdirectory(hopper)
+  add_subdirectory(layout)
+  add_subdirectory(msvc_compilation)
 
-add_custom_target(
-  cutlass_test_unit_cute
-  DEPENDS
-  cutlass_test_unit_cute_layout
-  cutlass_test_unit_cute_core
-  cutlass_test_unit_cute_volta
-  cutlass_test_unit_cute_turing
-  cutlass_test_unit_cute_ampere
-  cutlass_test_unit_cute_hopper
-  cutlass_test_unit_cute_msvc_compilation
-  )
+  add_custom_target(
+    cutlass_test_unit_cute
+    DEPENDS
+    cutlass_test_unit_cute_layout
+    cutlass_test_unit_cute_core
+    cutlass_test_unit_cute_volta
+    cutlass_test_unit_cute_turing
+    cutlass_test_unit_cute_ampere
+    cutlass_test_unit_cute_hopper
+    cutlass_test_unit_cute_msvc_compilation
+    )
 
-add_custom_target(
-  test_unit_cute
-  DEPENDS
-  test_unit_cute_layout
-  test_unit_cute_core
-  test_unit_cute_volta
-  test_unit_cute_ampere
-  test_unit_cute_turing
-  test_unit_cute_hopper
-  test_unit_cute_msvc_compilation
-  )
+  add_custom_target(
+    test_unit_cute
+    DEPENDS
+    test_unit_cute_layout
+    test_unit_cute_core
+    test_unit_cute_volta
+    test_unit_cute_ampere
+    test_unit_cute_turing
+    test_unit_cute_hopper
+    test_unit_cute_msvc_compilation
+    )
+else()
+  add_subdirectory(layout)
+
+  add_custom_target(
+    cutlass_test_unit_cute
+    DEPENDS
+    cutlass_test_unit_cute_layout
+    )
+
+  add_custom_target(
+    test_unit_cute
+    DEPENDS
+    test_unit_cute_layout
+    )
+endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -34,7 +34,7 @@ if (CUTLASS_ENABLE_LIBRARY)
   add_subdirectory(library)
 endif()
 
-if (CUTLASS_ENABLE_PROFILER)
+if (CUTLASS_ENABLE_PROFILER AND NOT CUTLASS_ENABLE_SYCL)
   if (NOT CUTLASS_ENABLE_LIBRARY)
     message(SEND_ERROR "Build conflict: The CUTLASS profiler requires the CUTLASS library.")
     message(SEND_ERROR "  CUTLASS_ENABLE_PROFILER = ${CUTLASS_ENABLE_PROFILER}")

--- a/tools/library/CMakeLists.txt
+++ b/tools/library/CMakeLists.txt
@@ -211,47 +211,49 @@ endfunction()
 
 ################################################################################
 
-cutlass_add_cutlass_library(
+if (NOT CUTLASS_ENABLE_SYCL)
 
-  src/handle.cu
-  src/manifest.cpp
-  src/operation_table.cu
-  src/singleton.cu
-  src/util.cu
+  cutlass_add_cutlass_library(
 
-  # files split for parallel compilation
-  src/reference/gemm_int4.cu
-  src/reference/gemm_int8_canonical.cu
-  src/reference/gemm_int8_interleaved_32.cu
-  src/reference/gemm_int8_interleaved_64.cu
-  src/reference/gemm_e4m3a_e4m3out.cu
-  src/reference/gemm_e5m2a_e4m3out.cu
-  src/reference/gemm_e4m3a_e5m2out.cu
-  src/reference/gemm_e5m2a_e5m2out.cu
-  src/reference/gemm_fp8in_fp16out.cu
-  src/reference/gemm_fp8in_bf16out.cu
-  src/reference/gemm_fp8in_fp32out.cu
-  src/reference/gemm_fp32out.cu
-  src/reference/gemm_fp_other.cu
-  src/reference/gemm_fp_mixed_input.cu
-  src/reference/initialize_reference_operations.cu
+    src/handle.cu
+    src/manifest.cpp
+    src/operation_table.cu
+    src/singleton.cu
+    src/util.cu
 
-  # cutlass reduction instances in cutlass library
+    # files split for parallel compilation
+    src/reference/gemm_int4.cu
+    src/reference/gemm_int8_canonical.cu
+    src/reference/gemm_int8_interleaved_32.cu
+    src/reference/gemm_int8_interleaved_64.cu
+    src/reference/gemm_e4m3a_e4m3out.cu
+    src/reference/gemm_e5m2a_e4m3out.cu
+    src/reference/gemm_e4m3a_e5m2out.cu
+    src/reference/gemm_e5m2a_e5m2out.cu
+    src/reference/gemm_fp8in_fp16out.cu
+    src/reference/gemm_fp8in_bf16out.cu
+    src/reference/gemm_fp8in_fp32out.cu
+    src/reference/gemm_fp32out.cu
+    src/reference/gemm_fp_other.cu
+    src/reference/gemm_fp_mixed_input.cu
+    src/reference/initialize_reference_operations.cu
 
-  src/reduction/reduction_device.cu
-  src/reduction/init_reduction_operations.cu
-  
-  # cutlass conv reference instances in cutlass library
+    # cutlass reduction instances in cutlass library
 
-  src/reference/conv2d.cu
-  src/reference/conv3d.cu
+    src/reduction/reduction_device.cu
+    src/reduction/init_reduction_operations.cu
+
+    # cutlass conv reference instances in cutlass library
+
+    src/reference/conv2d.cu
+    src/reference/conv3d.cu
 
   )
 
-# For backward compatibility with the old name
-add_library(cutlass_lib ALIAS cutlass_library)
-add_library(cutlass_lib_static ALIAS cutlass_library_static)
-
+  # For backward compatibility with the old name
+  add_library(cutlass_lib ALIAS cutlass_library)
+  add_library(cutlass_lib_static ALIAS cutlass_library_static)
+endif()
 ################################################################################
 
 file(GLOB_RECURSE GENERATOR_PYTHON_SOURCES CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/scripts/*.py)
@@ -295,12 +297,14 @@ endif()
 
 message(STATUS "Completed generation of library instances. See ${CMAKE_CURRENT_BINARY_DIR}/library_instance_generation.log for more information.")
 
-# include auto-instantiated kernels in he CUTLASS Deliverables Library
-set(CUTLASS_LIBRARY_MANIFEST_CMAKE_FILE ${CMAKE_CURRENT_BINARY_DIR}/generated/manifest.cmake)
-if(EXISTS "${CUTLASS_LIBRARY_MANIFEST_CMAKE_FILE}")
-  include(${CUTLASS_LIBRARY_MANIFEST_CMAKE_FILE})
-else()
-  message(STATUS "auto-generated library manifest cmake file (${CUTLASS_LIBRARY_MANIFEST_CMAKE_FILE}) not found.")
+if (NOT CUTLASS_ENABLE_SYCL)
+  # include auto-instantiated kernels in he CUTLASS Deliverables Library
+  set(CUTLASS_LIBRARY_MANIFEST_CMAKE_FILE ${CMAKE_CURRENT_BINARY_DIR}/generated/manifest.cmake)
+  if(EXISTS "${CUTLASS_LIBRARY_MANIFEST_CMAKE_FILE}")
+    include(${CUTLASS_LIBRARY_MANIFEST_CMAKE_FILE})
+  else()
+    message(STATUS "auto-generated library manifest cmake file (${CUTLASS_LIBRARY_MANIFEST_CMAKE_FILE}) not found.")
+  endif()
 endif()
 
 ################################################################################

--- a/tools/util/include/cutlass/util/sycl_event_manager.hpp
+++ b/tools/util/include/cutlass/util/sycl_event_manager.hpp
@@ -1,0 +1,136 @@
+/***************************************************************************************************
+ * Copyright (c) 2024 - 2024 Codeplay Software Ltd. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+#pragma once
+
+#include <vector>
+#include <sycl/sycl.hpp>
+
+class SyclEvent {
+private:
+  int index;
+public:
+  SyclEvent() : index(-1) {
+  };
+
+  int getIndex() const {
+    return index;
+  }
+
+  SyclEvent& operator=(int const& value) {
+    index = value;
+    return *this;
+  };
+};
+
+class EventManager {
+public:
+  static EventManager& getInstance()
+  {
+    static EventManager instance;
+    return instance;
+  }
+private:
+  EventManager() {}
+  std::vector<sycl::event> events{};
+  int recorders = 0;
+
+public:
+  EventManager(EventManager const&) = delete;
+  void operator=(EventManager const&) = delete;
+
+  void startRecording(SyclEvent &event) {
+    if (event.getIndex() != -1) {
+      throw std::runtime_error("Event is already being recorded.");
+    }
+    recorders++;
+    event = static_cast<int>(events.size());
+  }
+
+  void addEvent(const sycl::event &event) {
+    events.push_back(event);
+  }
+
+  void eventDestroy() {
+    recorders--;
+    if (!recorders) {
+      events.clear();
+    }
+  }
+
+  float getEventElapsedTimeMs(SyclEvent const& begin, SyclEvent const& end) const {
+    if (begin.getIndex() < 0 || begin.getIndex() > end.getIndex() || end.getIndex() > events.size()) {
+      throw std::runtime_error("Index out of bounds");
+    }
+
+    auto time_event = 0.0f;
+#if defined(SYCLCOMPAT_PROFILING_ENABLED)
+    for (int i = begin.getIndex(); i < end.getIndex(); ++i) {
+      const auto start_time = events[i].template get_profiling_info<
+              sycl::info::event_profiling::command_start>();
+
+      const auto end_time = events[i].template get_profiling_info<
+              sycl::info::event_profiling::command_end>();
+
+      time_event += static_cast<float>(end_time - start_time);
+    }
+#else
+    CUTLASS_ASSERT(false && "Profiling information can not be collected. "
+                            "Define SYCLCOMPAT_PROFILING_ENABLED.");
+#endif
+    return time_event * 1e-6f;
+  }
+
+  void wait(SyclEvent const& begin, SyclEvent const& end) {
+    if (begin.getIndex() < 0 || begin.getIndex() > end.getIndex() || end.getIndex() > events.size()) {
+      throw std::runtime_error("Index out of bounds");
+    }
+
+    for (int i = begin.getIndex(); i < end.getIndex(); ++i) {
+      events[i].wait();
+    }
+  }
+};
+
+inline void syclEventDestroy(SyclEvent const&) {
+  EventManager::getInstance().eventDestroy();
+}
+
+inline void syclEventRecord(SyclEvent &event) {
+  EventManager::getInstance().startRecording(event);
+}
+
+inline void syclEventSynchronize(SyclEvent const& begin, SyclEvent const& end) {
+  EventManager::getInstance().wait(begin, end);
+}
+
+inline void syclEventElapsedTime(float* time, SyclEvent const& begin, SyclEvent const& end) {
+  *time = EventManager::getInstance().getEventElapsedTimeMs(begin, end);
+}


### PR DESCRIPTION
This PR is the first step towards enabling Cutlass 3 and Cute to build with SYCL support. This enhancement will significantly expand the compatibility and flexibility of Cutlass, allowing users to build and run Cutlass on a wider range of SYCL-enabled devices.

Key Changes:
* CMake Configuration: Modified the CMake configuration to introduce an alternative build using SYCL. Detailed instructions on how to build with SYCL, including any necessary prerequisites and configuration steps, have been added to the `media/docs` folder.

* Code Migration: Five examples in Cute tutorial have been migrated to SYCL with minimal modifications. Most changes involved adapting CUDA-specific code to be compatible with SYCL, ensuring minimal disruption to the existing codebase while maintaining performance and functionality. You will notice that the examples for SYCL have been added as separate files instead of reusing the existing examples. This is on purpose to reduce disruption in the actual codebase and keep the tutorial example simple and educational. The existing examples contain CUDA-specific code that need to be generalised for SYCL. Other than the CUDA-specific code, the examples are identical.

