### PR TITLE
Update syclcompat launch for PVC

### DIFF
--- a/cmake/FindDPCPP.cmake
+++ b/cmake/FindDPCPP.cmake
@@ -38,7 +38,7 @@ find_library(DPCPP_LIB_DIR NAMES sycl sycl6 PATHS "${DPCPP_BIN_DIR}/../lib")
 
 add_library(DPCPP::DPCPP INTERFACE IMPORTED)
 
-set(DPCPP_FLAGS "-fsycl;-mllvm;-enable-global-offset=false;")
+set(DPCPP_FLAGS "-fsycl;")
 if(NOT "${DPCPP_SYCL_TARGET}" STREQUAL "")
   list(APPEND DPCPP_FLAGS "-fsycl-targets=${DPCPP_SYCL_TARGET};")
 endif()
@@ -48,6 +48,7 @@ if(NOT "${DPCPP_SYCL_ARCH}" STREQUAL "")
   if("${DPCPP_SYCL_TARGET}" STREQUAL "nvptx64-nvidia-cuda")
     list(APPEND DPCPP_FLAGS "-Xsycl-target-backend")
     list(APPEND DPCPP_FLAGS "--cuda-gpu-arch=${DPCPP_SYCL_ARCH}")
+    list(APPEND DPCPP_FLAGS "-mllvm;-enable-global-offset=false;")
   endif()
 endif()
 

--- a/include/cutlass/gemm/device/gemm_universal_adapter.h
+++ b/include/cutlass/gemm/device/gemm_universal_adapter.h
@@ -60,6 +60,7 @@
 
 #if defined(CUTLASS_ENABLE_SYCL)
 #include "cutlass/util/sycl_event_manager.hpp"
+#include <syclcompat/syclcompat.hpp>
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -411,7 +412,11 @@ public:
         const auto sycl_grid = syclcompat::dim3(grid.x, grid.y, grid.z);
 
 #if defined (SYCL_INTEL_TARGET)
-        auto event = syclcompat::experimental::launch<device_kernel<GemmKernel>, DispatchPolicy::SubgroupSize>(sycl_grid, sycl_block, smem_size, params);
+        using namespace syclcompat::experimental;
+        auto event = launch<device_kernel<GemmKernel>>(launch_policy{
+          sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)}, 
+          kernel_properties{sycl_exp::sub_group_size<DispatchPolicy::SubgroupSize>}
+        }, params);
 #else
         auto event = syclcompat::launch<device_kernel<GemmKernel>>(sycl_grid, sycl_block, smem_size, params);
 #endif


### PR DESCRIPTION
intel/llvm#14441 removed the experimental launch interfaces for requesting a particular sub-group size with launch properties. This PR makes the required changes on our side.