### PR TITLE
Implement device_init for sycl

### DIFF
--- a/tools/util/include/cutlass/util/helper_cuda.hpp
+++ b/tools/util/include/cutlass/util/helper_cuda.hpp
@@ -43,6 +43,22 @@ namespace cute
 void
 device_init(int device_id, bool quiet = false)
 {
+
+#if defined(CUTLASS_ENABLE_SYCL)
+
+  syclcompat::select_device(device_id);
+  auto &device = syclcompat::get_current_device();
+  
+  if (!quiet) {
+    printf("Using device %d: %s  (%d Compute Units)\n",
+           device_id, device.get_device_info().get_name(),
+           device.get_max_compute_units()
+           );
+    fflush(stdout);
+  }
+
+#else  
+
   cudaDeviceProp device_prop;
   std::size_t    device_free_physmem;
   std::size_t    device_total_physmem;
@@ -65,6 +81,9 @@ device_init(int device_id, bool quiet = false)
            device_prop.multiProcessorCount);
     fflush(stdout);
   }
+
+#endif
+
 }
 
 /**


### PR DESCRIPTION
Maybe we should change the file name.

I was trying to port this:
https://github.com/ColfaxResearch/cfx-article-src/blob/1c1009764cc6af8e4a3c4b04aea264ded93ff70d/transpose-cute/include/copy.h#L52

It turns out that they don't use `device_init()`, but it seems handy to have anyway.