### PR TITLE
Fix syclcompat launcher for nvidia

### DIFF
--- a/include/cutlass/gemm/device/gemm_universal_adapter.h
+++ b/include/cutlass/gemm/device/gemm_universal_adapter.h
@@ -410,14 +410,16 @@ public:
         const auto sycl_block = syclcompat::dim3(block.x, block.y, block.z);
         const auto sycl_grid = syclcompat::dim3(grid.x, grid.y, grid.z);
 
-#if defined (SYCL_INTEL_TARGET)
         using namespace syclcompat::experimental;
+#if defined (SYCL_INTEL_TARGET)
         auto event = launch<device_kernel<GemmKernel>>(launch_policy{
           sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)}, 
           kernel_properties{sycl_exp::sub_group_size<DispatchPolicy::SubgroupSize>}
         }, params);
 #else
-        auto event = syclcompat::launch<device_kernel<GemmKernel>>(sycl_grid, sycl_block, smem_size, params);
+        auto event = launch<device_kernel<GemmKernel>>(launch_policy{
+          sycl_grid, sycl_block, local_mem_size{static_cast<std::size_t>(smem_size)}},
+          params);
 #endif
         EventManager::getInstance().addEvent(event);
 #else


### PR DESCRIPTION
This PR fixes the syclcompat launcher for the nvidia pipeline. Related to https://github.com/codeplaysoftware/cutlass-fork/pull/106