### PR TITLE
Expose prefetch distance

### DIFF
--- a/benchmarks/pvc/bench_pvc_gemm_bf16_bf16_fp32_dpas_fp32.cpp
+++ b/benchmarks/pvc/bench_pvc_gemm_bf16_bf16_fp32_dpas_fp32.cpp
@@ -95,7 +95,8 @@ int main(int argc, const char** argv)
   using GmemTiledCopyA = XE_2D_U16x8x16x4x2_LD_N;
   using GmemTiledCopyB = XE_2D_U16x16x16x2x2_V;
 
-  using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVCUnpredicated;
+  constexpr int PipelineStages = 3;
+  using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVC<PipelineStages>;
   using EpilogueDispatchPolicy = cutlass::epilogue::IntelPVCEpilogue;
 
   using EpilogueOp = cutlass::epilogue::fusion::LinearCombination<ElementOutput, ElementComputeEpilogue,

--- a/examples/sycl/pvc/pvc_gemm.cpp
+++ b/examples/sycl/pvc/pvc_gemm.cpp
@@ -349,7 +349,8 @@ int main(int argc, const char** argv)
           Layout<Shape<_1,_1,_1>>,
           Tile<_32,_64,_32>>; // Subgroup level-tile
 
-  using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVCUnpredicated;
+  constexpr int PipelineStages = 3;
+  using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVC<PipelineStages>;
   using EpilogueDispatchPolicy = cutlass::epilogue::IntelPVCEpilogue;
 
   using EpilogueOp = cutlass::epilogue::fusion::LinearCombination<ElementOutput, ElementComputeEpilogue,

--- a/examples/sycl/pvc/pvc_gemm_with_epilogue_relu.cpp
+++ b/examples/sycl/pvc/pvc_gemm_with_epilogue_relu.cpp
@@ -350,7 +350,8 @@ int main(int argc, const char** argv)
           Layout<Shape<_1,_1,_1>>,
           Tile<_32,_64,_32>>;  // Subgroup level-tile
 
-  using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVCUnpredicated;
+  constexpr int PipelineStages = 3;
+  using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVC<PipelineStages>;
   using EpilogueDispatchPolicy = cutlass::epilogue::IntelPVCEpilogue;
 
   using EpilogueOp = cutlass::epilogue::fusion::LinCombEltAct<cutlass::epilogue::thread::ReLu, ElementOutput,

--- a/include/cutlass/gemm/collective/intel_pvc_mma.hpp
+++ b/include/cutlass/gemm/collective/intel_pvc_mma.hpp
@@ -45,6 +45,7 @@ using namespace cute;
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <
+  int Stages,
   class TileShape_,
   class ElementA_,
   class StrideA_,
@@ -60,7 +61,7 @@ template <
   class SmemCopyAtomB_,
   class TransformB_>
 struct CollectiveMma<
-    MainloopIntelPVCUnpredicated,
+    MainloopIntelPVC<Stages>,
     TileShape_,
     ElementA_,
     StrideA_,
@@ -79,7 +80,7 @@ struct CollectiveMma<
   //
   // Type Aliases
   //
-  using DispatchPolicy = MainloopIntelPVCUnpredicated;
+  using DispatchPolicy = MainloopIntelPVC<Stages>;
   using WorkgroupTileShape = TileShape_;
   using ElementA = ElementA_;
   using StrideA = StrideA_;
@@ -232,10 +233,7 @@ struct CollectiveMma<
     //
     int prefetch_k = 0;
 
-    // Manually set the prefetch_distance to 3
-    // TODO: Expose to users like stages parameter
-    int constexpr prefetch_distance = 3;
-    for (int i = 0; i < prefetch_distance; i++) {
+    for (int i = 0; i < DispatchPolicy::Stages; i++) {
       prefetch(mainloop.gmem_tiled_copy_a, tAi(_, _, prefetch_k));
       prefetch(mainloop.gmem_tiled_copy_b, tBi(_, _, prefetch_k));
       prefetch_k += get<2>(SubgroupTileShape{});

--- a/include/cutlass/gemm/dispatch_policy.hpp
+++ b/include/cutlass/gemm/dispatch_policy.hpp
@@ -89,7 +89,6 @@ static constexpr bool Has_SwapAB_v = Has_SwapAB<T>::value;
 //
 // Kernel schedule policies (the base class tags, one for each kernel layer file)
 //
-struct KernelSinglestage { };
 struct KernelMultistage { };
 struct KernelCpAsyncWarpSpecialized { };
 struct KernelCpAsyncWarpSpecializedPingpong { };
@@ -99,6 +98,8 @@ struct KernelTmaWarpSpecialized { };
 struct KernelTmaWarpSpecializedPingpong { };
 struct KernelTmaWarpSpecializedCooperative { };
 struct KernelPtrArrayTmaWarpSpecializedCooperative { };
+
+struct KernelPVC { };
 
 //////////////////////////////////////////////////////////////////////////////
 
@@ -293,15 +294,14 @@ struct MainloopSm90ArrayTmaGmmaWarpSpecialized {
 
 
 #if defined(SYCL_INTEL_TARGET)
-struct MainloopIntelPVCBase {
-  constexpr static int Stages = 1;
+template<int Stages_>
+struct MainloopIntelPVC {
+  constexpr static int Stages = Stages_;
+  constexpr static int SubgroupSize = 16;
   using ArchTag = arch::IntelPVC;
-  using Schedule = KernelSinglestage;
+  using Schedule = KernelPVC;
   using ClusterShape = Shape<_1,_1,_1>;
-  static constexpr int SubgroupSize = 16;
 };
-
-struct MainloopIntelPVCUnpredicated : MainloopIntelPVCBase{};
 #endif
 
 //////////////////////////////////////////////////////////////////////////////

--- a/include/cutlass/gemm/kernel/intel_pvc_gemm.hpp
+++ b/include/cutlass/gemm/kernel/intel_pvc_gemm.hpp
@@ -52,7 +52,7 @@ class GemmUniversal<
   CollectiveMainloop_,
   CollectiveEpilogue_,
   TileScheduler_,
-  cute::enable_if_t<cute::is_base_of_v<KernelSinglestage, typename CollectiveMainloop_::DispatchPolicy::Schedule>>>
+  cute::enable_if_t<cute::is_base_of_v<KernelPVC, typename CollectiveMainloop_::DispatchPolicy::Schedule>>>
 {
 public:
   //


### PR DESCRIPTION
This PR adds a `stages` field in the dispatch policy used for PVC which will be used as the prefetch distance in the MMA implementation.

