### PR TITLE
Add local qualifier to the shared memory pointer

### DIFF
--- a/include/cutlass/device_kernel.h
+++ b/include/cutlass/device_kernel.h
@@ -109,7 +109,7 @@ void Kernel2(typename Operator::Params params) {
 /// Generic CUTLASS kernel template.
 template <typename Operator>
 #if defined(CUTLASS_ENABLE_SYCL)
-void device_kernel(typename Operator::Params const params, char* smem) {
+void device_kernel(typename Operator::Params const params, sycl::local_ptr<char> smem) {
 #else
 CUTLASS_GLOBAL
 #ifdef __CUDACC__


### PR DESCRIPTION
This PR uses `sycl::local_ptr` to add the `local` qualifier to the shared memory pointer passed by SYCLCompat. Without this qualifier, the compiler cannot identify it as shared memory and will generate generic instructions, relying on the underlying driver for optimisation. This was causing performance issues in the SM80 examples.