### PR TITLE
Add support for SYCL on example 35

### DIFF
--- a/examples/35_gemm_softmax/gemm_with_epilogue_visitor.h
+++ b/examples/35_gemm_softmax/gemm_with_epilogue_visitor.h
@@ -428,7 +428,7 @@ public:
     };
 
     // Compute position within threadblock
-    int thread_idx = threadIdx.x;
+    int thread_idx = ThreadIdxX();
 
     // Construct iterators to A and B operands
     typename Mma::IteratorA iterator_A(
@@ -447,9 +447,9 @@ public:
 
     // Broadcast the warp_id computed by lane 0 to ensure dependent code
     // is compiled as warp-uniform.
-    int warp_idx = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    int warp_idx = shfl_sync(0xffffffff, ThreadIdxX() / 32, 0);
 
-    int lane_idx = threadIdx.x % 32;
+    int lane_idx = ThreadIdxX() % 32;
 
     //
     // Main loop
@@ -505,7 +505,7 @@ public:
       params.ptr_Max,
       params.ptr_Sum,
       threadblock_offset,
-      blockIdx.y *params.problem_size.m() );
+      BlockIdxY() *params.problem_size.m() );
 
     if (params.mode == GemmUniversalMode::kGemm) {
       // Indicate which position in a serial reduction the output operator is currently updating

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -155,6 +155,7 @@ if (NOT CUTLASS_ENABLE_SYCL)
 else()
   foreach(EXAMPLE
     14_ampere_tf32_tensorop_gemm
+    35_gemm_softmax
     cute
     sycl
     )

--- a/include/cute/util/debug.hpp
+++ b/include/cute/util/debug.hpp
@@ -36,7 +36,7 @@
  */
 
 #if defined(CUTLASS_ENABLE_SYCL)
-#include <sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <syclcompat.hpp>
 #else
 #include <cuda_runtime_api.h>

--- a/include/cutlass/arch/memory.h
+++ b/include/cutlass/arch/memory.h
@@ -65,6 +65,8 @@ struct global_load;
      (__CUDACC_VER_MAJOR__ > 11)) &&                                  \
     defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 750)
   #define CUTLASS_ENABLE_L2_PREFETCH 1
+#elif defined(__SYCL_CUDA_ARCH__) && (__SYCL_CUDA_ARCH__ >= 750)
+  #define CUTLASS_ENABLE_L2_PREFETCH 1
 #else
   #define CUTLASS_ENABLE_L2_PREFETCH 0
 #endif

--- a/include/cutlass/arch/memory_sm80.h
+++ b/include/cutlass/arch/memory_sm80.h
@@ -41,7 +41,7 @@
 #include "cutlass/arch/memory_sm75.h"
 #include "cutlass/arch/cache_operation.h"
 
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)) || (defined(__SYCL_CUDA_ARCH__) && (__SYCL_CUDA_ARCH__ >= 800))
   #define CUDA_CP_ASYNC_ACTIVATED 1
 #else
   #define CUDA_CP_ASYNC_ACTIVATED 0
@@ -194,7 +194,7 @@ struct cp_async_nan<16, CacheOperation::Always> {
   cp_async_nan(void *smem_ptr, void const *global_ptr, bool pred_guard) {
     #if CUDA_CP_ASYNC_ACTIVATED
 
-      static __constant__ uint4 OOB_NAN_F16x8 = {OOB_NAN_F16x2, OOB_NAN_F16x2,
+      static CUTLASS_CONSTANT uint4 OOB_NAN_F16x8 = {OOB_NAN_F16x2, OOB_NAN_F16x2,
                                                  OOB_NAN_F16x2, OOB_NAN_F16x2};
 
       unsigned smem_int_ptr = cutlass_get_smem_pointer(smem_ptr);
@@ -236,9 +236,9 @@ struct cp_async_diag <Element_, false> {
     #if CUDA_CP_ASYNC_ACTIVATED
 
       /// Values for the diagonal elements of the triangular input matrix
-      static __constant__ uint2 DIAG_DATA_DOUBLE_ONE = {0x3ff00000, 0x00000000};
-      static __constant__ uint1 DIAG_DATA_FLOAT_ONE = {0x3f800000};
-      static __constant__ uint1 DIAG_DATA_ZERO = {0x00000000};
+      static CUTLASS_CONSTANT uint2 DIAG_DATA_DOUBLE_ONE = {0x3ff00000, 0x00000000};
+      static CUTLASS_CONSTANT uint1 DIAG_DATA_FLOAT_ONE = {0x3f800000};
+      static CUTLASS_CONSTANT uint1 DIAG_DATA_ZERO = {0x00000000};
 
       unsigned smem_int_ptr = cutlass_get_smem_pointer(smem_ptr);
 
@@ -283,7 +283,7 @@ struct cp_async_diag <Element_, true> {
     #if CUDA_CP_ASYNC_ACTIVATED
 
       /// Values for the diagonal elements of the triangular input matrix
-      static __constant__ uint1 DIAG_DATA_ZERO = {0x00000000};
+      static CUTLASS_CONSTANT uint1 DIAG_DATA_ZERO = {0x00000000};
 
       unsigned smem_int_ptr = cutlass_get_smem_pointer(smem_ptr);
 
@@ -397,7 +397,7 @@ struct cp_async_nan<16, CacheOperation::Global> {
   cp_async_nan(void *smem_ptr, void const *global_ptr, bool pred_guard) {
     #if CUDA_CP_ASYNC_ACTIVATED
 
-      static __constant__ uint4 OOB_NAN_F16x8 = {OOB_NAN_F16x2, OOB_NAN_F16x2,
+      static CUTLASS_CONSTANT uint4 OOB_NAN_F16x8 = {OOB_NAN_F16x2, OOB_NAN_F16x2,
                                                  OOB_NAN_F16x2, OOB_NAN_F16x2};
 
       unsigned smem_int_ptr = cutlass_get_smem_pointer(smem_ptr);

--- a/include/cutlass/arch/mma_sm80.h
+++ b/include/cutlass/arch/mma_sm80.h
@@ -47,11 +47,13 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#if ((__CUDACC_VER_MAJOR__ > 11) || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 0))
+#if ((__CUDACC_VER_MAJOR__ > 11) || (__CUDACC_VER_MAJOR__ == 11 && __CUDACC_VER_MINOR__ >= 0)) || \
+    defined(CUTLASS_ENABLE_SYCL)
 
 #define CUTLASS_ARCH_MMA_SM80_SUPPORTED 1
 
-#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800))
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)) || \
+    (defined(__SYCL_CUDA_ARCH__) && (__SYCL_CUDA_ARCH__ >= 800))
 #define CUTLASS_ARCH_MMA_SM80_ENABLED
 
 #if (__CUDA_ARCH__ <= 900)

--- a/include/cutlass/detail/helper_macros.hpp
+++ b/include/cutlass/detail/helper_macros.hpp
@@ -69,6 +69,13 @@
 #define CUTLASS_GLOBAL __global__ static
 #define CUTLASS_SHARED __shared__
 #endif
+
+#if defined(__CUDA_ARCH__)
+#define CUTLASS_CONSTANT __constant__
+#else
+#define CUTLASS_CONSTANT constexpr
+#endif
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 template<typename T>

--- a/include/cutlass/epilogue/threadblock/epilogue_visitor_with_softmax.h
+++ b/include/cutlass/epilogue/threadblock/epilogue_visitor_with_softmax.h
@@ -381,11 +381,11 @@ public:
     // Compute accumulate sum only in the last step
     accum_sum_ = warp_reduce_sum_(accum_sum_);
 
-    bool is_first_thread_in_tile = ((threadIdx.x % kThreadsPerRow) == 0);
+    bool is_first_thread_in_tile = ((ThreadIdxX() % kThreadsPerRow) == 0);
     bool row_guard = thread_offset_.row() < extent_.row();
     bool is_write_thread = row_guard && is_first_thread_in_tile;
 
-    int block_batch = blockIdx.z;
+    int block_batch = BlockIdxZ();
 
     ElementNorm *curr_ptr_max = ptr_Max_ + thread_offset_.row() + column_offset_ + block_batch * params_.batch_stride_Max;
     ElementSum *curr_ptr_sum = ptr_Sum_ + thread_offset_.row() + column_offset_ + block_batch * params_.batch_stride_Sum;
@@ -434,7 +434,7 @@ private:
     int half_thread_in_row = (kThreadsPerRow >> 1);
     CUTLASS_PRAGMA_UNROLL
     for (int i = half_thread_in_row; i > 0; i >>= 1) {
-      ElementSoftmaxCompute tmp = __shfl_xor_sync(0xFFFFFFFF, sum_, i);
+      ElementSoftmaxCompute tmp = shfl_xor_sync(0xFFFFFFFF, sum_, i);
       sum_ += tmp;
     }
     return sum_;
@@ -445,7 +445,7 @@ private:
     int half_thread_in_row = (kThreadsPerRow >> 1);
     CUTLASS_PRAGMA_UNROLL
     for (int i = half_thread_in_row; i > 0; i >>= 1) {
-      ElementSoftmaxCompute tmp = __shfl_xor_sync(0xFFFFFFFF, max_, i);
+      ElementSoftmaxCompute tmp = shfl_xor_sync(0xFFFFFFFF, max_, i);
       max_ = fast_max(max_, tmp);
     }
     return max_;

--- a/include/cutlass/epilogue/threadblock/epilogue_with_visitor.h
+++ b/include/cutlass/epilogue/threadblock/epilogue_with_visitor.h
@@ -275,12 +275,12 @@ public:
       // Convert and store fragment
       //
 
-      __syncthreads();
+      syncthreads();
 
       acc2smem_source_needed<cutlass::make_index_sequence<Visitor::kIterations>>::push(
           iter_idx, accum_fragment_iterator, this->warp_tile_iterator_);
 
-      __syncthreads();
+      syncthreads();
 
       //
       // Load fragments from shared memory

--- a/include/cutlass/gemm/warp/mma_tensor_op.h
+++ b/include/cutlass/gemm/warp/mma_tensor_op.h
@@ -217,7 +217,8 @@ public:
   /// Number of partitions along K dimension
   static int const kPartitionsK = PartitionsK_;
 
-  #if defined(__CUDA_ARCH__) && ((__CUDA_ARCH__ < 800) || (__CUDA_ARCH__ == 890)) 
+  #if (defined(__CUDA_ARCH__) && ((__CUDA_ARCH__ < 800) || (__CUDA_ARCH__ == 890))) || \
+      (defined(__SYCL_CUDA_ARCH__) && ((__SYCL_CUDA_ARCH__ < 800) || (__SYCL_CUDA_ARCH__ == 890)))
     static int const kVerticalVisit = true;
   #else
     static int const kVerticalVisit = false;

--- a/include/cutlass/gpu_generics.h
+++ b/include/cutlass/gpu_generics.h
@@ -295,6 +295,18 @@ unsigned int shfl_sync(
 #endif
 }
 
+template <typename T>
+CUTLASS_DEVICE
+T shfl_xor_sync(unsigned mask, T var, int laneMask, int width=NumThreadsPerWarp) {
+#if defined(__CUDA_ARCH__)
+  return __shfl_xor_sync(mask, var, laneMask, width);
+#elif defined(__SYCL_DEVICE_ONLY__)
+  auto g = syclcompat::get_nd_item<1>().get_sub_group();
+  return syclcompat::permute_sub_group_by_xor(g, var, laneMask, width);
+#else
+  return T(0.0);
+#endif
+}
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /*
@@ -324,7 +336,7 @@ CUTLASS_DEVICE int atomicAdd(int *address, int val) {
 
 CUTLASS_DEVICE int atomicCAS(int *address, int compare, int val) {
 #if defined(__SYCL_DEVICE_ONLY__)
-  syclcompat::atomic_compare_exchange_strong(address, compare, val);
+  return syclcompat::atomic_compare_exchange_strong(address, compare, val);
 #endif
   return 0;
 }

--- a/include/cutlass/reduction/kernel/reduce_softmax_final.h
+++ b/include/cutlass/reduction/kernel/reduce_softmax_final.h
@@ -182,11 +182,11 @@ private:
   CUTLASS_DEVICE
   void apply(Params const &params, SharedStorage &shared_storage) {
 
-    int tid = threadIdx.x;
-    int bid = blockIdx.x;
-    int bdim = blockDim.x;
+    int tid = ThreadIdxX();
+    int bid = BlockIdxX();
+    int bdim = BlockDimX();
     
-    int block_batch = blockIdx.z;
+    int block_batch = BlockIdxZ();
 
     // defining three vars for a general reduction module
     cutlass::gemm::GemmCoord problem_size = isGroupedProblem ? params.args.problem_sizes[bid] : params.args.problem_size;

--- a/include/cutlass/sycl_vector_types.h
+++ b/include/cutlass/sycl_vector_types.h
@@ -45,6 +45,10 @@ using int4 = struct alignas(16) {
   int x, y, z, w;
 };
 
+using uint1 = struct alignas(4) {
+  unsigned int x;
+};
+
 using uint2 = struct alignas(8) {
   unsigned int x, y;
 };

--- a/include/cutlass/transform/threadblock/predicated_tile_access_iterator.h
+++ b/include/cutlass/transform/threadblock/predicated_tile_access_iterator.h
@@ -186,6 +186,10 @@ class PredicatedTileAccessIteratorPredicates {
   CUTLASS_HOST_DEVICE
   void set_predicates(int thread_id, TensorCoord const &threadblock_offset) {
 
+#if defined(CUTLASS_ENABLE_SYCL)
+    using namespace sycl;
+#endif
+
     TensorCoord residue_extent;
     if (kAdvanceRank) {
 


### PR DESCRIPTION
This PR adds support for SYCL to the original Cutlass 2 example 35. The focus of this PR is only on functionality. Performance optimisations will be addressed in a separate PR to ensure that execution with SYCL can match the performance achieved with cuda.