### PR TITLE
Define GmemTiledCopyA/B as TiledCopy in CollectiveMma<IntelPVC,...

### DIFF
--- a/examples/sycl/pvc/pvc_gemm.cpp
+++ b/examples/sycl/pvc/pvc_gemm.cpp
@@ -376,7 +376,9 @@ int main(int argc, const char** argv)
   >;
 
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
-
+  //TODO(joe): Added this temporarily to verify that the GmemTiledCopyA is a genuine TiledCopy
+  static int constexpr kAlignmentA = cutlass::detail::get_alignment_count_from_gmem_tiled_copy<
+      typename CollectiveMainloop::GmemTiledCopyA, ElementInputA, typename CollectiveMainloop::TiledMma::ValTypeA>();
   ExampleRunner<Gemm> runner;
 
   runner.run(options, hw_info);


### PR DESCRIPTION
This matches what EVT test suite expects, and seems to be consistent with sm80 impls.

This change would also imply updating the `pvc_gemm*cpp` examples.