### PR TITLE
Unit test for IntelPVC w/ LinCombEltAct EVT

### DIFF
--- a/SYCL.cmake
+++ b/SYCL.cmake
@@ -55,7 +55,7 @@ endfunction()
 
 function(cutlass_add_executable NAME)
   set(options)
-  set(oneValueArgs BATCH_SOURCES)
+  set(oneValueArgs BATCH_SOURCES BATCH_SIZE) #Important to define these so they aren't passed to add_executable
   set(multiValueArgs)
   cmake_parse_arguments(_ "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 

--- a/include/cutlass/epilogue/collective/builders/xe_builder.inl
+++ b/include/cutlass/epilogue/collective/builders/xe_builder.inl
@@ -79,7 +79,7 @@ template <
                         cutlass::epilogue::fusion::LinearCombination<ElementD,ElementCompute,ElementC,ElementCompute>> ||
         cute::is_same_v<FusionOpOrCallbacks,
                         cutlass::epilogue::fusion::LinCombEltAct<cutlass::epilogue::thread::ReLu,
-                        ElementD,ElementCompute,ElementC,ElementCompute>> ||
+                        ElementD, ElementCompute, ElementC, ElementCompute>> ||
         cute::is_same_v<FusionOpOrCallbacks,
                         cutlass::epilogue::fusion::LinCombEltAct<cutlass::epilogue::thread::Identity,
                         ElementD,ElementCompute,ElementC,ElementCompute>>)

--- a/include/cutlass/epilogue/collective/builders/xe_builder.inl
+++ b/include/cutlass/epilogue/collective/builders/xe_builder.inl
@@ -79,6 +79,9 @@ template <
                         cutlass::epilogue::fusion::LinearCombination<ElementD,ElementCompute,ElementC,ElementCompute>> ||
         cute::is_same_v<FusionOpOrCallbacks,
                         cutlass::epilogue::fusion::LinCombEltAct<cutlass::epilogue::thread::ReLu,
+                        ElementD,ElementCompute,ElementC,ElementCompute>> ||
+        cute::is_same_v<FusionOpOrCallbacks,
+                        cutlass::epilogue::fusion::LinCombEltAct<cutlass::epilogue::thread::Identity,
                         ElementD,ElementCompute,ElementC,ElementCompute>>)
       >
     >{

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -135,6 +135,7 @@ add_custom_target(test_unit)
 if (CUTLASS_ENABLE_SYCL)
   set(SUBDIRS
     cute
+    gemm
   )
 else()
   set(SUBDIRS

--- a/test/unit/gemm/CMakeLists.txt
+++ b/test/unit/gemm/CMakeLists.txt
@@ -26,6 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+if(NOT CUTLASS_ENABLE_SYCL)
 add_subdirectory(thread)
 add_subdirectory(warp)
 add_subdirectory(threadblock)
@@ -48,4 +49,19 @@ add_custom_target(
   test_unit_gemm_threadblock
   test_unit_gemm_device
   )
+else()
 
+add_subdirectory(device)
+
+add_custom_target(
+  cutlass_test_unit_gemm
+  DEPENDS
+  cutlass_test_unit_gemm_device
+  )
+
+add_custom_target(
+  test_unit_gemm
+  DEPENDS
+  test_unit_gemm_device
+  )
+endif()

--- a/test/unit/gemm/CMakeLists.txt
+++ b/test/unit/gemm/CMakeLists.txt
@@ -27,41 +27,41 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 if(NOT CUTLASS_ENABLE_SYCL)
-add_subdirectory(thread)
-add_subdirectory(warp)
-add_subdirectory(threadblock)
-add_subdirectory(device)
+  add_subdirectory(thread)
+  add_subdirectory(warp)
+  add_subdirectory(threadblock)
+  add_subdirectory(device)
 
-add_custom_target(
-  cutlass_test_unit_gemm
-  DEPENDS
-  cutlass_test_unit_gemm_thread
-  cutlass_test_unit_gemm_warp
-  cutlass_test_unit_gemm_threadblock
-  cutlass_test_unit_gemm_device
+  add_custom_target(
+    cutlass_test_unit_gemm
+    DEPENDS
+    cutlass_test_unit_gemm_thread
+    cutlass_test_unit_gemm_warp
+    cutlass_test_unit_gemm_threadblock
+    cutlass_test_unit_gemm_device
   )
 
-add_custom_target(
-  test_unit_gemm
-  DEPENDS
-  test_unit_gemm_thread
-  test_unit_gemm_warp
-  test_unit_gemm_threadblock
-  test_unit_gemm_device
+  add_custom_target(
+    test_unit_gemm
+    DEPENDS
+    test_unit_gemm_thread
+    test_unit_gemm_warp
+    test_unit_gemm_threadblock
+    test_unit_gemm_device
   )
 else()
 
-add_subdirectory(device)
+  add_subdirectory(device)
 
-add_custom_target(
-  cutlass_test_unit_gemm
-  DEPENDS
-  cutlass_test_unit_gemm_device
+  add_custom_target(
+    cutlass_test_unit_gemm
+    DEPENDS
+    cutlass_test_unit_gemm_device
   )
 
-add_custom_target(
-  test_unit_gemm
-  DEPENDS
-  test_unit_gemm_device
+  add_custom_target(
+    test_unit_gemm
+    DEPENDS
+    test_unit_gemm_device
   )
 endif()

--- a/test/unit/gemm/device/CMakeLists.txt
+++ b/test/unit/gemm/device/CMakeLists.txt
@@ -352,7 +352,7 @@ cutlass_test_unit_add_executable(
 if(SYCL_INTEL_TARGET)
 cutlass_test_unit_add_executable(
   cutlass_test_unit_gemm_device_tensorop_epilogue_fusion_xe
-  xe_gemm_f8_f8_bf16_tensor_op_fp32_evt.cpp
+  xe_gemm_bf16_bf16_fp32_tensor_op_fp32_evt.cpp
 )
 endif()
 

--- a/test/unit/gemm/device/CMakeLists.txt
+++ b/test/unit/gemm/device/CMakeLists.txt
@@ -348,7 +348,7 @@ cutlass_test_unit_add_executable(
   sm90_gemm_f8_f8_bf16_tensor_op_fp32_evt.cu
   sm90_gemm_f8_f8_f32_tensor_op_f32_cluster_warpspecialized_cooperative_evt.cu
 )
-# TODO(joe): ninja test_unit_gemm_device_tensorop_epilogue_fusion_xe
+
 cutlass_test_unit_add_executable(
   cutlass_test_unit_gemm_device_tensorop_epilogue_fusion_xe
   xe_gemm_f8_f8_bf16_tensor_op_fp32_evt.cpp

--- a/test/unit/gemm/device/CMakeLists.txt
+++ b/test/unit/gemm/device/CMakeLists.txt
@@ -348,6 +348,11 @@ cutlass_test_unit_add_executable(
   sm90_gemm_f8_f8_bf16_tensor_op_fp32_evt.cu
   sm90_gemm_f8_f8_f32_tensor_op_f32_cluster_warpspecialized_cooperative_evt.cu
 )
+# TODO(joe): ninja test_unit_gemm_device_tensorop_epilogue_fusion_xe
+cutlass_test_unit_add_executable(
+  cutlass_test_unit_gemm_device_tensorop_epilogue_fusion_xe
+  xe_gemm_f8_f8_bf16_tensor_op_fp32_evt.cpp
+)
 cutlass_test_unit_add_executable(
   cutlass_test_unit_gemm_device_tensorop_cluster_multicast_sm90
 

--- a/test/unit/gemm/device/CMakeLists.txt
+++ b/test/unit/gemm/device/CMakeLists.txt
@@ -349,10 +349,13 @@ cutlass_test_unit_add_executable(
   sm90_gemm_f8_f8_f32_tensor_op_f32_cluster_warpspecialized_cooperative_evt.cu
 )
 
+if(SYCL_INTEL_TARGET)
 cutlass_test_unit_add_executable(
   cutlass_test_unit_gemm_device_tensorop_epilogue_fusion_xe
   xe_gemm_f8_f8_bf16_tensor_op_fp32_evt.cpp
 )
+endif()
+
 cutlass_test_unit_add_executable(
   cutlass_test_unit_gemm_device_tensorop_cluster_multicast_sm90
 

--- a/test/unit/gemm/device/CMakeLists.txt
+++ b/test/unit/gemm/device/CMakeLists.txt
@@ -350,10 +350,10 @@ cutlass_test_unit_add_executable(
 )
 
 if(SYCL_INTEL_TARGET)
-cutlass_test_unit_add_executable(
-  cutlass_test_unit_gemm_device_tensorop_epilogue_fusion_xe
-  xe_gemm_bf16_bf16_fp32_tensor_op_fp32_evt.cpp
-)
+  cutlass_test_unit_add_executable(
+    cutlass_test_unit_gemm_device_tensorop_epilogue_fusion_xe
+    xe_gemm_bf16_bf16_fp32_tensor_op_fp32_evt.cpp
+  )
 endif()
 
 cutlass_test_unit_add_executable(

--- a/test/unit/gemm/device/CMakeLists.txt
+++ b/test/unit/gemm/device/CMakeLists.txt
@@ -44,6 +44,10 @@ if(CUTLASS_ENABLE_SYCL)
       DEPENDS
       test_unit_gemm_device_tensorop_epilogue_fusion_xe
     )
+  else()
+    # Dummy targets if not building for Intel
+    add_custom_target(cutlass_test_unit_gemm_device)
+    add_custom_target(test_unit_gemm_device)
   endif()
 else()
 

--- a/test/unit/gemm/device/CMakeLists.txt
+++ b/test/unit/gemm/device/CMakeLists.txt
@@ -26,7 +26,28 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-add_custom_target(
+if(CUTLASS_ENABLE_SYCL)
+  if(SYCL_INTEL_TARGET)
+    cutlass_test_unit_add_executable(
+      cutlass_test_unit_gemm_device_tensorop_epilogue_fusion_xe
+      xe_gemm_bf16_bf16_fp32_tensor_op_fp32_evt.cpp
+    )
+
+    add_custom_target(
+      cutlass_test_unit_gemm_device
+      DEPENDS
+      cutlass_test_unit_gemm_device_tensorop_epilogue_fusion_xe
+    )
+
+    add_custom_target(
+      test_unit_gemm_device
+      DEPENDS
+      test_unit_gemm_device_tensorop_epilogue_fusion_xe
+    )
+  endif()
+else()
+
+  add_custom_target(
   cutlass_test_unit_gemm_device
   DEPENDS
   cutlass_test_unit_gemm_device_simt
@@ -349,14 +370,7 @@ cutlass_test_unit_add_executable(
   sm90_gemm_f8_f8_f32_tensor_op_f32_cluster_warpspecialized_cooperative_evt.cu
 )
 
-if(SYCL_INTEL_TARGET)
   cutlass_test_unit_add_executable(
-    cutlass_test_unit_gemm_device_tensorop_epilogue_fusion_xe
-    xe_gemm_bf16_bf16_fp32_tensor_op_fp32_evt.cpp
-  )
-endif()
-
-cutlass_test_unit_add_executable(
   cutlass_test_unit_gemm_device_tensorop_cluster_multicast_sm90
 
   BATCH_SOURCES ON
@@ -823,4 +837,4 @@ cutlass_test_unit_add_executable(
 )
 
 endif()
-
+endif()

--- a/test/unit/gemm/device/gemm_testbed_3x.hpp
+++ b/test/unit/gemm/device/gemm_testbed_3x.hpp
@@ -1809,11 +1809,11 @@ bool TestXe(
   // For K, we currently only support K = TileShapeK
   // We set L = 1 throughout
   int max_alignment = 4; //std::max(Gemm::kAlignmentA, Gemm::kAlignmentB);
-  std::vector<int> problem_size_m = {max_alignment, 512 - 3 * max_alignment};
-  std::vector<int> problem_size_n = {max_alignment, 512 - 2 * max_alignment};
+  std::vector<int> problem_size_m{max_alignment, 512 - 3 * max_alignment};
+  std::vector<int> problem_size_n{max_alignment, 512 - 2 * max_alignment};
 
   constexpr int TileShapeK = cute::size<2>(typename Gemm::GemmKernel::TileShape{});
-  std::vector<int> problem_size_k = {TileShapeK};
+  std::vector<int> problem_size_k{TileShapeK};
 
   bool passed = true;
 

--- a/test/unit/gemm/device/gemm_testbed_3x.hpp
+++ b/test/unit/gemm/device/gemm_testbed_3x.hpp
@@ -697,7 +697,6 @@ struct HostCollectiveEpilogue {
   // FusionOperation derived types/queries
   //
   using EpiloguePolicy = typename Epilogue::DispatchPolicy;
-  //TODO(joe): test this correctly catches the legacy case...
   static constexpr bool IsLegacy = IsLegacyEpiloguePolicy<EpiloguePolicy>::value;
 
   using FusionOp = typename Gemm::EpilogueOutputOp;

--- a/test/unit/gemm/device/gemm_testbed_3x.hpp
+++ b/test/unit/gemm/device/gemm_testbed_3x.hpp
@@ -1416,9 +1416,13 @@ struct TestbedImpl {
       }
     }
 
-    //TODO(joe): exception handling here?
 #if defined(CUTLASS_ENABLE_SYCL)
-    syclcompat::wait();
+    try {
+      syclcompat::wait_and_throw();
+    } catch (std::exception const &e) {
+      ADD_FAILURE() << "Error at Kernel Sync.";
+      return false;
+    }
 #else
     cudaError_t result;
     result = cudaDeviceSynchronize();
@@ -1520,9 +1524,14 @@ struct TestbedImpl {
     else {
       status = gemm_op.initialize(arguments, workspace.get());
       status = gemm_op.run();
-      //TODO(joe): exception handling here?
+
 #if defined(CUTLASS_ENABLE_SYCL)
-    syclcompat::wait();
+      try {
+        syclcompat::wait_and_throw();
+      } catch (std::exception const &e) {
+        ADD_FAILURE() << "Error at Kernel Sync.";
+        return false;
+      }
 #else
       cudaError_t result;
       result = cudaDeviceSynchronize();

--- a/test/unit/gemm/device/gemm_testbed_3x.hpp
+++ b/test/unit/gemm/device/gemm_testbed_3x.hpp
@@ -1808,7 +1808,8 @@ bool TestXe(
   // For M & N we test a small and a big size
   // For K, we currently only support K = TileShapeK
   // We set L = 1 throughout
-  int max_alignment = 4; //std::max(Gemm::kAlignmentA, Gemm::kAlignmentB);
+  // TODO(codeplay): unhardcode max_alignment
+  int max_alignment = 4;
   std::vector<int> problem_size_m{max_alignment, 512 - 3 * max_alignment};
   std::vector<int> problem_size_n{max_alignment, 512 - 2 * max_alignment};
 

--- a/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_evt.cpp
+++ b/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_evt.cpp
@@ -48,7 +48,7 @@
 using namespace cute;
 
 // D = activation(alpha * acc + beta * C)
-TEST(XE_Device_Gemm_bf16t_bf16t_f32_tensor_op_gmma_f32_epilogue, 256x256x32_LinCombEltAct) {
+TEST(XE_Device_Gemm_bf16t_bf16t_f32t_tensor_op_gmma_f32_epilogue, 256x256x32_LinCombEltAct) {
   using LayoutA = cutlass::layout::RowMajor;
   using LayoutB = cutlass::layout::RowMajor;
   using LayoutC = cutlass::layout::RowMajor;

--- a/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_evt.cpp
+++ b/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_evt.cpp
@@ -102,7 +102,7 @@ TEST(XE_Device_Gemm_bf16t_bf16t_f32t_tensor_op_gmma_f32_epilogue, 256x256x32_Lin
 
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
 
-  bool passed = test::gemm::device::TestXe<Gemm, cutlass::epilogue::thread::ReLu>(1.0, 0.0);
+  bool passed = test::gemm::device::TestXe<Gemm, cutlass::epilogue::thread::ReLu>(1.0, 1.0);
   EXPECT_TRUE(passed);
 }
 

--- a/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_evt.cpp
+++ b/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_evt.cpp
@@ -102,7 +102,7 @@ TEST(XE_Device_Gemm_bf16t_bf16t_f32t_tensor_op_gmma_f32_epilogue, 256x256x32_Lin
 
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
 
-  bool passed = test::gemm::device::TestSingleShapeXe<Gemm, cutlass::epilogue::thread::ReLu>(1.0, 0.0);
+  bool passed = test::gemm::device::TestXe<Gemm, cutlass::epilogue::thread::ReLu>(1.0, 0.0);
   EXPECT_TRUE(passed);
 }
 

--- a/test/unit/gemm/device/xe_gemm_f8_f8_bf16_tensor_op_fp32_evt.cpp
+++ b/test/unit/gemm/device/xe_gemm_f8_f8_bf16_tensor_op_fp32_evt.cpp
@@ -1,0 +1,197 @@
+/***************************************************************************************************
+ * Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **************************************************************************************************/
+
+/*! \file
+    \brief Tests for Sm90 f8_f8_bf16 with EVT epilogue 
+    ScaledLinCombPerRowBiasEltAct and ScaledLinCombPerRowBiasEltActAmaxAux
+*/
+
+#include <iostream>
+
+#include "cutlass/cutlass.h"
+#include "cute/tensor.hpp"
+#include "cute/atom/mma_atom.hpp"
+
+#include "cutlass/numeric_types.h"
+
+#include "cutlass/gemm/device/gemm_universal_adapter.h"
+#include "cutlass/gemm/kernel/gemm_universal.hpp"
+#include "cutlass/epilogue/collective/collective_builder.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/epilogue/collective/sm70_epilogue_vectorized.hpp"
+#include "cutlass/epilogue/collective/default_epilogue.hpp"
+#include "cutlass/epilogue/thread/linear_combination.h"
+#include "cutlass/epilogue/thread/linear_combination_bias_elementwise.h"
+
+#include "../../common/cutlass_unit_test.h"
+
+#include "gemm_testbed_3x_evt.hpp"
+#include "sm90_evt_operations.hpp"
+
+
+#if defined(CUTLASS_ARCH_MMA_SM90_SUPPORTED)
+
+using namespace cute;
+
+// Z = scale_a * scale_b * alpha * acc + beta * scale_c * C + per-row bias
+// if D is fp8 
+//   D = scale_d * activation(Z)
+// else
+//   D = activation(Z)
+TEST(SM90_Device_Gemm_e4m3t_e4m3n_bf16t_tensor_op_gmma_f32_epilogue, 64x128x128_ScaledLinCombPerRowBiasEltAct) {
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutC = cutlass::layout::RowMajor;
+  using TileShape_MNK = Shape<_64,_128,_128>;
+  using ClusterShape_MNK = Shape<_1,_1,_1>;
+
+  using EpilogueSchedule = cutlass::epilogue::TmaWarpSpecialized;
+  using FusionCallbacks = cutlass::epilogue::fusion::Sm90ScaledLinCombPerRowBiasEltAct<
+    TileShape_MNK,                      // CtaTileShapeMNK
+    cutlass::epilogue::thread::ReLu,    // ActivationFn
+    cutlass::bfloat16_t,                // ElementOutput
+    float,                              // ElementCompute
+    cutlass::bfloat16_t                 // ElementBias
+  >;
+
+  using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+      cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+      TileShape_MNK, ClusterShape_MNK,
+      cutlass::epilogue::collective::EpilogueTileAuto,
+      float, float,
+      cutlass::bfloat16_t, LayoutC, 8,
+      cutlass::bfloat16_t, LayoutC, 8,
+      EpilogueSchedule,
+      FusionCallbacks
+    >::CollectiveOp;
+
+  using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+      cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+      cutlass::float_e4m3_t, LayoutA, 16,
+      cutlass::float_e4m3_t, LayoutB, 16,
+      float,
+      TileShape_MNK, ClusterShape_MNK,
+      cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(sizeof(typename CollectiveEpilogue::SharedStorage))>,
+      cutlass::gemm::KernelTmaWarpSpecialized
+    >::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+      Shape<int,int,int,int>,
+      CollectiveMainloop,
+      CollectiveEpilogue
+  >;
+
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+  // Host reference
+  using HostReference = test::gemm::device::HostScaledLinCombPerRowBiasEltAct<
+    Gemm, cutlass::epilogue::thread::ReLu, cutlass::bfloat16_t
+  >;
+  bool passed = test::gemm::device::TestAllEVT<Gemm, HostReference>(true);
+  EXPECT_TRUE(passed);
+}
+
+// Z = scale_a * scale_b * alpha * acc + scale_c * beta * C + per-row bias
+// if D is fp8 
+//   amax_d = max(abs(elements in activation(Z)))
+//   D = scale_d * activation(Z)
+// else
+//   D = activation(Z)
+// if Aux is fp8 
+//   amax_aux = max(abs(elements in Z))
+//   Aux = scale_aux * Z
+// else
+//   Aux = Z
+TEST(SM90_Device_Gemm_e4m3t_e4m3n_bf16n_tensor_op_gmma_f32_epilogue, 64x128x128_4x1x1_ScaledLinCombPerRowBiasEltActAmaxAux) {
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutC = cutlass::layout::ColumnMajor;
+  using TileShape_MNK = Shape<_64,_128,_128>;
+  using ClusterShape_MNK = Shape<_2,_4,_1>;
+
+  using EpilogueSchedule = cutlass::epilogue::TmaWarpSpecialized;
+  using EpilogueTileType = cutlass::epilogue::collective::EpilogueTileAuto;
+  using EpilogueDescriptor = cutlass::epilogue::collective::detail::EpilogueDescriptor<
+    TileShape_MNK, EpilogueTileType, cutlass::bfloat16_t, cutlass::bfloat16_t, EpilogueSchedule>;
+  using AuxStoreDescriptor = cutlass::epilogue::collective::detail::AuxStoreDescriptor<
+    EpilogueDescriptor, cutlass::layout::RowMajor, cutlass::bfloat16_t>;
+    
+  using FusionCallbacks = cutlass::epilogue::fusion::Sm90ScaledLinCombPerRowBiasEltActAmaxAux<
+    TileShape_MNK,                               // CtaTileShapeMNK
+    typename EpilogueDescriptor::EpilogueTile,   // EpilogueTile
+    EpilogueDescriptor::StagesD,                 // StagesD
+    typename AuxStoreDescriptor::Stride,         // StrideAux
+    typename AuxStoreDescriptor::SmemLayoutAtom, // SmemLayoutAtom
+    typename AuxStoreDescriptor::CopyOpR2S,      // CopyOpR2S
+    cutlass::epilogue::thread::ReLu,             // ActivationFn
+    cutlass::bfloat16_t,                         // ElementOutput
+    float,                                       // ElementCompute
+    cutlass::bfloat16_t,                         // ElementBias
+    float                                        // ElementScalar
+  >;
+
+  using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+      cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+      TileShape_MNK, ClusterShape_MNK,
+      EpilogueTileType,
+      float, float,
+      cutlass::bfloat16_t, LayoutC, 16,
+      cutlass::bfloat16_t, LayoutC, 16,
+      EpilogueSchedule,
+      FusionCallbacks
+    >::CollectiveOp;
+
+  using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+      cutlass::arch::Sm90, cutlass::arch::OpClassTensorOp,
+      cutlass::float_e4m3_t, LayoutA, 16,
+      cutlass::float_e4m3_t, LayoutB, 16,
+      float,
+      TileShape_MNK, ClusterShape_MNK,
+      cutlass::gemm::collective::StageCountAutoCarveout<static_cast<int>(sizeof(typename CollectiveEpilogue::SharedStorage))>,
+      cutlass::gemm::KernelTmaWarpSpecialized
+    >::CollectiveOp;
+
+  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+      Shape<int,int,int,int>,
+      CollectiveMainloop,
+      CollectiveEpilogue
+  >;
+
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+  // Host reference
+  using HostReference = test::gemm::device::HostScaledLinCombPerRowBiasEltActAmaxAux<
+    Gemm, cutlass::epilogue::thread::ReLu, cutlass::bfloat16_t
+  >;
+  bool passed = test::gemm::device::TestAllEVT<Gemm, HostReference>(true);
+  EXPECT_TRUE(passed);
+}
+#endif // defined(CUTLASS_ARCH_MMA_SM90_SUPPORTED)

--- a/test/unit/gemm/device/xe_gemm_f8_f8_bf16_tensor_op_fp32_evt.cpp
+++ b/test/unit/gemm/device/xe_gemm_f8_f8_bf16_tensor_op_fp32_evt.cpp
@@ -102,7 +102,7 @@ TEST(XE_Device_Gemm_bf16t_bf16t_f32_tensor_op_gmma_f32_epilogue, 256x256x32_LinC
 
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
 
-  bool passed = test::gemm::device::TestSingleShapeXe<Gemm>(1.0, 0.0);
+  bool passed = test::gemm::device::TestSingleShapeXe<Gemm, cutlass::epilogue::thread::ReLu>(1.0, 0.0);
   EXPECT_TRUE(passed);
 }
 

--- a/test/unit/gemm/device/xe_gemm_f8_f8_bf16_tensor_op_fp32_evt.cpp
+++ b/test/unit/gemm/device/xe_gemm_f8_f8_bf16_tensor_op_fp32_evt.cpp
@@ -30,46 +30,31 @@
  **************************************************************************************************/
 
 /*! \file
-    \brief Tests for Sm90 f8_f8_bf16 with EVT epilogue 
-    ScaledLinCombPerRowBiasEltAct and ScaledLinCombPerRowBiasEltActAmaxAux
+    \brief Tests for Xe bf16t_bf16t_f32 with EVT epilogue
+    LinCombEltAct
 */
 
 #include <iostream>
 
 #include "cutlass/cutlass.h"
-#include "cute/tensor.hpp"
-#include "cute/atom/mma_atom.hpp"
-
-#include "cutlass/numeric_types.h"
 
 #include "cutlass/gemm/device/gemm_universal_adapter.h"
 #include "cutlass/gemm/kernel/gemm_universal.hpp"
 #include "cutlass/epilogue/collective/collective_builder.hpp"
 #include "cutlass/gemm/collective/collective_builder.hpp"
-#include "cutlass/epilogue/collective/xe_epilogue.hpp"
-#include "cutlass/epilogue/collective/default_epilogue.hpp"
-#include "cutlass/epilogue/thread/linear_combination.h"
-#include "cutlass/epilogue/thread/linear_combination_bias_elementwise.h"
 
-#include "../../common/cutlass_unit_test.h"
-
-#include "gemm_testbed_3x_evt.hpp"
-#include "sm90_evt_operations.hpp"
-
-
+#include "gemm_testbed_3x.hpp"
 
 using namespace cute;
 
-// Z = scale_a * scale_b * alpha * acc + beta * scale_c * C + per-row bias
-// if D is fp8 
-//   D = scale_d * activation(Z)
-// else
-//   D = activation(Z)
-TEST(XE_Device_Gemm_e4m3t_e4m3n_bf16t_tensor_op_gmma_f32_epilogue, 64x128x128_ScaledLinCombPerRowBiasEltAct) {
+// D = activation(alpha * acc + beta * C)
+TEST(XE_Device_Gemm_bf16t_bf16t_f32_tensor_op_gmma_f32_epilogue, 256x256x32_LinCombEltAct) {
   using LayoutA = cutlass::layout::RowMajor;
   using LayoutB = cutlass::layout::RowMajor;
   using LayoutC = cutlass::layout::RowMajor;
-  using TileShape_MNK = Shape<_64,_128,_128>;
+  using LayoutD = cutlass::layout::RowMajor;
+
+  using TileShape_MNK = Shape<_256, _256, _32>;
   using ClusterShape_MNK = Shape<_1,_1,_1>;
 
   using EpilogueSchedule = cutlass::epilogue::collective::EpilogueScheduleAuto;
@@ -79,7 +64,11 @@ TEST(XE_Device_Gemm_e4m3t_e4m3n_bf16t_tensor_op_gmma_f32_epilogue, 64x128x128_Sc
   using ElementInputB = bfloat16_t;
   using ElementOutput = float;
 
-  //TODO(joe): Do LinCombPerRowBias...
+  constexpr int AlignmentA = sizeof(ElementInputA);
+  constexpr int AlignmentB = sizeof(ElementInputB);
+  constexpr int AlignmentC = sizeof(ElementAccumulator);
+  constexpr int AlignmentD = sizeof(ElementOutput);
+
   using FusionCallbacks = cutlass::epilogue::fusion::LinCombEltAct<cutlass::epilogue::thread::ReLu, 
           ElementOutput, ElementComputeEpilogue, ElementAccumulator, 
           ElementAccumulator, cutlass::FloatRoundStyle::round_to_nearest>;
@@ -89,16 +78,16 @@ TEST(XE_Device_Gemm_e4m3t_e4m3n_bf16t_tensor_op_gmma_f32_epilogue, 64x128x128_Sc
       TileShape_MNK, ClusterShape_MNK,
       cutlass::epilogue::collective::EpilogueTileAuto,
       ElementComputeEpilogue, ElementAccumulator,
-      ElementAccumulator, LayoutC, 8,
-      ElementOutput, LayoutC, 8,
+      ElementAccumulator, LayoutC, AlignmentC,
+      ElementOutput, LayoutD, AlignmentD,
       EpilogueSchedule,
       FusionCallbacks
     >::CollectiveOp;
 
   using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
       cutlass::arch::IntelPVC, cutlass::arch::OpClassTensorOp,
-      ElementInputA, LayoutA, 16,
-      ElementInputB, LayoutB, 16,
+      ElementInputA, LayoutA, AlignmentA,
+      ElementInputB, LayoutB, AlignmentB,
       ElementAccumulator,
       TileShape_MNK, ClusterShape_MNK,
       cutlass::gemm::collective::StageCountAuto,
@@ -113,86 +102,7 @@ TEST(XE_Device_Gemm_e4m3t_e4m3n_bf16t_tensor_op_gmma_f32_epilogue, 64x128x128_Sc
 
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
 
-  // Host reference
-  using HostReference = test::gemm::device::HostScaledLinCombPerRowBiasEltAct<
-    Gemm, cutlass::epilogue::thread::ReLu, cutlass::bfloat16_t
-  >;
-  bool passed = test::gemm::device::TestAllEVT<Gemm, HostReference>(true);
+  bool passed = test::gemm::device::TestSingleShapeXe<Gemm>(1.0, 0.0);
   EXPECT_TRUE(passed);
 }
 
-// Z = scale_a * scale_b * alpha * acc + scale_c * beta * C + per-row bias
-// if D is fp8 
-//   amax_d = max(abs(elements in activation(Z)))
-//   D = scale_d * activation(Z)
-// else
-//   D = activation(Z)
-// if Aux is fp8 
-//   amax_aux = max(abs(elements in Z))
-//   Aux = scale_aux * Z
-// else
-//   Aux = Z
-// TEST(XE_Device_Gemm_e4m3t_e4m3n_bf16n_tensor_op_gmma_f32_epilogue, 64x128x128_4x1x1_LinCombEltAct) {
-//   using LayoutA = cutlass::layout::RowMajor;
-//   using LayoutB = cutlass::layout::ColumnMajor;
-//   using LayoutC = cutlass::layout::ColumnMajor;
-//   using TileShape_MNK = Shape<_64,_128,_128>;
-//   using ClusterShape_MNK = Shape<_2,_4,_1>;
-//
-//   using EpilogueSchedule = cutlass::epilogue::collective::EpilogueScheduleAuto;
-//   using EpilogueTileType = cutlass::epilogue::collective::EpilogueTileAuto;
-//   using EpilogueDescriptor = cutlass::epilogue::collective::detail::EpilogueDescriptor<
-//     TileShape_MNK, EpilogueTileType, cutlass::bfloat16_t, cutlass::bfloat16_t, EpilogueSchedule>;
-//   using AuxStoreDescriptor = cutlass::epilogue::collective::detail::AuxStoreDescriptor<
-//     EpilogueDescriptor, cutlass::layout::RowMajor, cutlass::bfloat16_t>;
-//
-//   using FusionCallbacks = cutlass::epilogue::fusion::Sm90LinCombEltAct<
-//     TileShape_MNK,                               // CtaTileShapeMNK
-//     typename EpilogueDescriptor::EpilogueTile,   // EpilogueTile
-//     EpilogueDescriptor::StagesD,                 // StagesD
-//     typename AuxStoreDescriptor::Stride,         // StrideAux
-//     typename AuxStoreDescriptor::SmemLayoutAtom, // SmemLayoutAtom
-//     typename AuxStoreDescriptor::CopyOpR2S,      // CopyOpR2S
-//     cutlass::epilogue::thread::ReLu,             // ActivationFn
-//     cutlass::bfloat16_t,                         // ElementOutput
-//     float,                                       // ElementCompute
-//     cutlass::bfloat16_t,                         // ElementBias
-//     float                                        // ElementScalar
-//   >;
-//
-//   using CollectiveEpilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
-//       cutlass::arch::IntelPVC, cutlass::arch::OpClassTensorOp,
-//       TileShape_MNK, ClusterShape_MNK,
-//       EpilogueTileType,
-//       float, float,
-//       cutlass::bfloat16_t, LayoutC, 16,
-//       cutlass::bfloat16_t, LayoutC, 16,
-//       EpilogueSchedule,
-//       FusionCallbacks
-//     >::CollectiveOp;
-//
-//   using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder<
-//       cutlass::arch::IntelPVC, cutlass::arch::OpClassTensorOp,
-//       cutlass::float_e4m3_t, LayoutA, 16,
-//       cutlass::float_e4m3_t, LayoutB, 16,
-//       float,
-//       TileShape_MNK, ClusterShape_MNK,
-//       cutlass::gemm::collective::StageCountAuto,
-//       cutlass::gemm::collective::KernelScheduleAuto
-//     >::CollectiveOp;
-//
-//   using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-//       Shape<int,int,int,int>,
-//       CollectiveMainloop,
-//       CollectiveEpilogue
-//   >;
-//
-//   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
-//
-//   // Host reference
-//   using HostReference = test::gemm::device::HostLinCombEltAct<
-//     Gemm, cutlass::epilogue::thread::ReLu, cutlass::bfloat16_t
-//   >;
-//   bool passed = test::gemm::device::TestAllEVT<Gemm, HostReference>(true);
-//   EXPECT_TRUE(passed);
-// }

--- a/test/unit/gemm/device/xe_gemm_f8_f8_bf16_tensor_op_fp32_evt.cpp
+++ b/test/unit/gemm/device/xe_gemm_f8_f8_bf16_tensor_op_fp32_evt.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************************************
- * Copyright (c) 2023 - 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024 - 2024 Codeplay Software Ltd. All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
As a precursor to properly testing https://github.com/codeplaysoftware/cutlass-fork/pull/152, I have adapted the `gemm_testbed_3x.hpp` infrastructure slightly for Xe and added a single test case for `LinCombEltAct`, as that's something we know should work. Need to:
 - [x] Check my changes to `IsLegacy` works w/ Nvidia's hardware
 - [ ] Add a range of global shapes (and tile shapes?)
 - [x] Add SYCL-friendly device check logic in the test infrastructure