### PR TITLE
Various chores

### DIFF
--- a/include/cute/arch/xe_copy_1B.hpp
+++ b/include/cute/arch/xe_copy_1B.hpp
@@ -37,13 +37,13 @@
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_BUILTIN(x) SYCL_EXTERNAL extern "C" x
 #else
-#define SYCL_DEVICE_BUILTIN(x) inline x { assert(false); CUTE_GCC_UNREACHABLE;}
+#define SYCL_DEVICE_BUILTIN(x) inline x { CUTE_SYCL_UNUSED;}
 #endif
 
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_OCL(x) SYCL_EXTERNAL x
 #else
-#define SYCL_DEVICE_OCL(x) inline x { assert(false); CUTE_GCC_UNREACHABLE;}
+#define SYCL_DEVICE_OCL(x) inline x { CUTE_SYCL_UNUSED;}
 #endif
 
 using namespace cute;

--- a/include/cute/arch/xe_copy_1B.hpp
+++ b/include/cute/arch/xe_copy_1B.hpp
@@ -37,13 +37,13 @@
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_BUILTIN(x) SYCL_EXTERNAL extern "C" x
 #else
-#define SYCL_DEVICE_BUILTIN(x) inline x { assert(false); }
+#define SYCL_DEVICE_BUILTIN(x) inline x { assert(false); CUTE_GCC_UNREACHABLE;}
 #endif
 
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_OCL(x) SYCL_EXTERNAL x
 #else
-#define SYCL_DEVICE_OCL(x) inline x { assert(false); }
+#define SYCL_DEVICE_OCL(x) inline x { assert(false); CUTE_GCC_UNREACHABLE;}
 #endif
 
 using namespace cute;

--- a/include/cute/arch/xe_copy_1B.hpp
+++ b/include/cute/arch/xe_copy_1B.hpp
@@ -37,13 +37,13 @@
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_BUILTIN(x) SYCL_EXTERNAL extern "C" x
 #else
-#define SYCL_DEVICE_BUILTIN(x) inline x { CUTE_SYCL_UNUSED;}
+#define SYCL_DEVICE_BUILTIN(x) inline x { CUTE_INVALID_CONTROL_PATH("Attempting to use a device built-in in host code.");}
 #endif
 
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_OCL(x) SYCL_EXTERNAL x
 #else
-#define SYCL_DEVICE_OCL(x) inline x { CUTE_SYCL_UNUSED;}
+#define SYCL_DEVICE_OCL(x) inline x { CUTE_INVALID_CONTROL_PATH("Attempting to use a device built-in in host code.");}
 #endif
 
 using namespace cute;

--- a/include/cute/arch/xe_copy_1B.hpp
+++ b/include/cute/arch/xe_copy_1B.hpp
@@ -37,13 +37,21 @@
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_BUILTIN(x) SYCL_EXTERNAL extern "C" x
 #else
-#define SYCL_DEVICE_BUILTIN(x) inline x { CUTE_INVALID_CONTROL_PATH("Attempting to use a device built-in in host code.");}
+#define SYCL_DEVICE_BUILTIN(x)                                                 \
+  inline x {                                                                   \
+    CUTE_INVALID_CONTROL_PATH(                                                 \
+        "Attempting to use a device built-in in host code.");                  \
+  }
 #endif
 
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_OCL(x) SYCL_EXTERNAL x
 #else
-#define SYCL_DEVICE_OCL(x) inline x { CUTE_INVALID_CONTROL_PATH("Attempting to use a device built-in in host code.");}
+#define SYCL_DEVICE_OCL(x)                                                     \
+  inline x {                                                                   \
+    CUTE_INVALID_CONTROL_PATH(                                                 \
+        "Attempting to use a device built-in in host code.");                  \
+  }
 #endif
 
 using namespace cute;

--- a/include/cute/arch/xe_copy_2B.hpp
+++ b/include/cute/arch/xe_copy_2B.hpp
@@ -38,13 +38,21 @@
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_BUILTIN(x) SYCL_EXTERNAL extern "C" x
 #else
-#define SYCL_DEVICE_BUILTIN(x) inline x { CUTE_INVALID_CONTROL_PATH("Attempting to use a device built-in in host code.");}
+#define SYCL_DEVICE_BUILTIN(x)                                                 \
+  inline x {                                                                   \
+    CUTE_INVALID_CONTROL_PATH(                                                 \
+        "Attempting to use a device built-in in host code.");                  \
+  }
 #endif
 
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_OCL(x) SYCL_EXTERNAL x
 #else
-#define SYCL_DEVICE_OCL(x) inline x { CUTE_INVALID_CONTROL_PATH("Attempting to use a device built-in in host code.");}
+#define SYCL_DEVICE_OCL(x)                                                     \
+  inline x {                                                                   \
+    CUTE_INVALID_CONTROL_PATH(                                                 \
+        "Attempting to use a device built-in in host code.");                  \
+  }
 #endif
 
 using namespace cute;

--- a/include/cute/arch/xe_copy_2B.hpp
+++ b/include/cute/arch/xe_copy_2B.hpp
@@ -38,13 +38,13 @@
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_BUILTIN(x) SYCL_EXTERNAL extern "C" x
 #else
-#define SYCL_DEVICE_BUILTIN(x) inline x { assert(false); CUTE_GCC_UNREACHABLE;}
+#define SYCL_DEVICE_BUILTIN(x) inline x { CUTE_SYCL_UNUSED;}
 #endif
 
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_OCL(x) SYCL_EXTERNAL x
 #else
-#define SYCL_DEVICE_OCL(x) inline x { assert(false); CUTE_GCC_UNREACHABLE;}
+#define SYCL_DEVICE_OCL(x) inline x { CUTE_SYCL_UNUSED;}
 #endif
 
 using namespace cute;

--- a/include/cute/arch/xe_copy_2B.hpp
+++ b/include/cute/arch/xe_copy_2B.hpp
@@ -38,13 +38,13 @@
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_BUILTIN(x) SYCL_EXTERNAL extern "C" x
 #else
-#define SYCL_DEVICE_BUILTIN(x) inline x { assert(false); }
+#define SYCL_DEVICE_BUILTIN(x) inline x { assert(false); CUTE_GCC_UNREACHABLE;}
 #endif
 
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_OCL(x) SYCL_EXTERNAL x
 #else
-#define SYCL_DEVICE_OCL(x) inline x { assert(false); }
+#define SYCL_DEVICE_OCL(x) inline x { assert(false); CUTE_GCC_UNREACHABLE;}
 #endif
 
 using namespace cute;

--- a/include/cute/arch/xe_copy_2B.hpp
+++ b/include/cute/arch/xe_copy_2B.hpp
@@ -38,13 +38,13 @@
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_BUILTIN(x) SYCL_EXTERNAL extern "C" x
 #else
-#define SYCL_DEVICE_BUILTIN(x) inline x { CUTE_SYCL_UNUSED;}
+#define SYCL_DEVICE_BUILTIN(x) inline x { CUTE_INVALID_CONTROL_PATH("Attempting to use a device built-in in host code.");}
 #endif
 
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_OCL(x) SYCL_EXTERNAL x
 #else
-#define SYCL_DEVICE_OCL(x) inline x { CUTE_SYCL_UNUSED;}
+#define SYCL_DEVICE_OCL(x) inline x { CUTE_INVALID_CONTROL_PATH("Attempting to use a device built-in in host code.");}
 #endif
 
 using namespace cute;

--- a/include/cute/arch/xe_copy_4B.hpp
+++ b/include/cute/arch/xe_copy_4B.hpp
@@ -37,13 +37,13 @@
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_BUILTIN(x) SYCL_EXTERNAL extern "C" x
 #else
-#define SYCL_DEVICE_BUILTIN(x) inline x { assert(false); CUTE_GCC_UNREACHABLE;}
+#define SYCL_DEVICE_BUILTIN(x) inline x { CUTE_SYCL_UNUSED;}
 #endif
 
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_OCL(x) SYCL_EXTERNAL x
 #else
-#define SYCL_DEVICE_OCL(x) inline x { assert(false); CUTE_GCC_UNREACHABLE;}
+#define SYCL_DEVICE_OCL(x) inline x { CUTE_SYCL_UNUSED;}
 #endif
 
 enum class CacheControl {

--- a/include/cute/arch/xe_copy_4B.hpp
+++ b/include/cute/arch/xe_copy_4B.hpp
@@ -37,13 +37,21 @@
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_BUILTIN(x) SYCL_EXTERNAL extern "C" x
 #else
-#define SYCL_DEVICE_BUILTIN(x) inline x { CUTE_INVALID_CONTROL_PATH("Attempting to use a device built-in in host code.");}
+#define SYCL_DEVICE_BUILTIN(x)                                                 \
+  inline x {                                                                   \
+    CUTE_INVALID_CONTROL_PATH(                                                 \
+        "Attempting to use a device built-in in host code.");                  \
+  }
 #endif
 
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_OCL(x) SYCL_EXTERNAL x
 #else
-#define SYCL_DEVICE_OCL(x) inline x { CUTE_INVALID_CONTROL_PATH("Attempting to use a device built-in in host code.");}
+#define SYCL_DEVICE_OCL(x)                                                     \
+  inline x {                                                                   \
+    CUTE_INVALID_CONTROL_PATH(                                                 \
+        "Attempting to use a device built-in in host code.");                  \
+  }
 #endif
 
 enum class CacheControl {

--- a/include/cute/arch/xe_copy_4B.hpp
+++ b/include/cute/arch/xe_copy_4B.hpp
@@ -37,13 +37,13 @@
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_BUILTIN(x) SYCL_EXTERNAL extern "C" x
 #else
-#define SYCL_DEVICE_BUILTIN(x) inline x { assert(false); }
+#define SYCL_DEVICE_BUILTIN(x) inline x { assert(false); CUTE_GCC_UNREACHABLE;}
 #endif
 
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_OCL(x) SYCL_EXTERNAL x
 #else
-#define SYCL_DEVICE_OCL(x) inline x { assert(false); }
+#define SYCL_DEVICE_OCL(x) inline x { assert(false); CUTE_GCC_UNREACHABLE;}
 #endif
 
 enum class CacheControl {

--- a/include/cute/arch/xe_copy_4B.hpp
+++ b/include/cute/arch/xe_copy_4B.hpp
@@ -37,13 +37,13 @@
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_BUILTIN(x) SYCL_EXTERNAL extern "C" x
 #else
-#define SYCL_DEVICE_BUILTIN(x) inline x { CUTE_SYCL_UNUSED;}
+#define SYCL_DEVICE_BUILTIN(x) inline x { CUTE_INVALID_CONTROL_PATH("Attempting to use a device built-in in host code.");}
 #endif
 
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_OCL(x) SYCL_EXTERNAL x
 #else
-#define SYCL_DEVICE_OCL(x) inline x { CUTE_SYCL_UNUSED;}
+#define SYCL_DEVICE_OCL(x) inline x { CUTE_INVALID_CONTROL_PATH("Attempting to use a device built-in in host code.");}
 #endif
 
 enum class CacheControl {

--- a/include/cute/arch/xe_copy_8B.hpp
+++ b/include/cute/arch/xe_copy_8B.hpp
@@ -37,13 +37,13 @@
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_BUILTIN(x) SYCL_EXTERNAL extern "C" x
 #else
-#define SYCL_DEVICE_BUILTIN(x) inline x { assert(false); CUTE_GCC_UNREACHABLE;}
+#define SYCL_DEVICE_BUILTIN(x) inline x { CUTE_SYCL_UNUSED;}
 #endif
 
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_OCL(x) SYCL_EXTERNAL x
 #else
-#define SYCL_DEVICE_OCL(x) inline x { assert(false); CUTE_GCC_UNREACHABLE;}
+#define SYCL_DEVICE_OCL(x) inline x { CUTE_SYCL_UNUSED;}
 #endif
 
 using namespace cute;

--- a/include/cute/arch/xe_copy_8B.hpp
+++ b/include/cute/arch/xe_copy_8B.hpp
@@ -37,13 +37,13 @@
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_BUILTIN(x) SYCL_EXTERNAL extern "C" x
 #else
-#define SYCL_DEVICE_BUILTIN(x) inline x { assert(false); }
+#define SYCL_DEVICE_BUILTIN(x) inline x { assert(false); CUTE_GCC_UNREACHABLE;}
 #endif
 
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_OCL(x) SYCL_EXTERNAL x
 #else
-#define SYCL_DEVICE_OCL(x) inline x { assert(false); }
+#define SYCL_DEVICE_OCL(x) inline x { assert(false); CUTE_GCC_UNREACHABLE;}
 #endif
 
 using namespace cute;

--- a/include/cute/arch/xe_copy_8B.hpp
+++ b/include/cute/arch/xe_copy_8B.hpp
@@ -37,13 +37,13 @@
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_BUILTIN(x) SYCL_EXTERNAL extern "C" x
 #else
-#define SYCL_DEVICE_BUILTIN(x) inline x { CUTE_SYCL_UNUSED;}
+#define SYCL_DEVICE_BUILTIN(x) inline x { CUTE_INVALID_CONTROL_PATH("Attempting to use a device built-in in host code.");}
 #endif
 
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_OCL(x) SYCL_EXTERNAL x
 #else
-#define SYCL_DEVICE_OCL(x) inline x { CUTE_SYCL_UNUSED;}
+#define SYCL_DEVICE_OCL(x) inline x { CUTE_INVALID_CONTROL_PATH("Attempting to use a device built-in in host code.");}
 #endif
 
 using namespace cute;

--- a/include/cute/arch/xe_copy_8B.hpp
+++ b/include/cute/arch/xe_copy_8B.hpp
@@ -37,13 +37,21 @@
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_BUILTIN(x) SYCL_EXTERNAL extern "C" x
 #else
-#define SYCL_DEVICE_BUILTIN(x) inline x { CUTE_INVALID_CONTROL_PATH("Attempting to use a device built-in in host code.");}
+#define SYCL_DEVICE_BUILTIN(x)                                                 \
+  inline x {                                                                   \
+    CUTE_INVALID_CONTROL_PATH(                                                 \
+        "Attempting to use a device built-in in host code.");                  \
+  }
 #endif
 
 #ifdef __SYCL_DEVICE_ONLY__
 #define SYCL_DEVICE_OCL(x) SYCL_EXTERNAL x
 #else
-#define SYCL_DEVICE_OCL(x) inline x { CUTE_INVALID_CONTROL_PATH("Attempting to use a device built-in in host code.");}
+#define SYCL_DEVICE_OCL(x)                                                     \
+  inline x {                                                                   \
+    CUTE_INVALID_CONTROL_PATH(                                                 \
+        "Attempting to use a device built-in in host code.");                  \
+  }
 #endif
 
 using namespace cute;

--- a/include/cute/config.hpp
+++ b/include/cute/config.hpp
@@ -130,7 +130,7 @@
 #define CUTE_STATIC_ASSERT_V(x,...) static_assert(decltype(x)::value, ##__VA_ARGS__)
 
 // Fail and print a message. Typically used for notification of a compiler misconfiguration.
-#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__)
 #  define CUTE_INVALID_CONTROL_PATH(x) assert(0 && x); printf(x); __brkpt()
 #elif defined(__has_builtin) && __has_builtin(__builtin_unreachable)
 #  define CUTE_INVALID_CONTROL_PATH(x) assert(0 && x); printf(x); __builtin_unreachable()

--- a/include/cute/config.hpp
+++ b/include/cute/config.hpp
@@ -102,10 +102,6 @@
 #  endif
 #endif
 
-#if !defined(CUTE_SYCL_UNUSED)
-#  define CUTE_SYCL_UNUSED assert(false); CUTE_GCC_UNREACHABLE
-#endif
-
 #if defined(_MSC_VER)
 // Provides support for alternative operators 'and', 'or', and 'not'
 #  include <iso646.h>

--- a/include/cute/config.hpp
+++ b/include/cute/config.hpp
@@ -130,7 +130,7 @@
 #define CUTE_STATIC_ASSERT_V(x,...) static_assert(decltype(x)::value, ##__VA_ARGS__)
 
 // Fail and print a message. Typically used for notification of a compiler misconfiguration.
-#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
 #  define CUTE_INVALID_CONTROL_PATH(x) assert(0 && x); printf(x); __brkpt()
 #elif defined(__has_builtin) && __has_builtin(__builtin_unreachable)
 #  define CUTE_INVALID_CONTROL_PATH(x) assert(0 && x); printf(x); __builtin_unreachable()

--- a/include/cute/config.hpp
+++ b/include/cute/config.hpp
@@ -102,6 +102,10 @@
 #  endif
 #endif
 
+#if !defined(CUTE_SYCL_UNUSED)
+#  define CUTE_SYCL_UNUSED assert(false); CUTE_GCC_UNREACHABLE
+#endif
+
 #if defined(_MSC_VER)
 // Provides support for alternative operators 'and', 'or', and 'not'
 #  include <iso646.h>

--- a/include/cutlass/arch/arch.h
+++ b/include/cutlass/arch/arch.h
@@ -47,7 +47,7 @@ namespace arch {
 CUTLASS_DEVICE
 int LaneId() {
   int ret;
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
   asm ("mov.u32 %0, %%laneid;" : "=r"(ret) : );
 #endif
   return ret;
@@ -57,7 +57,7 @@ int LaneId() {
 CUTLASS_DEVICE
 int SmId() {
   int ret;
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
   asm ("mov.u32 %0, %%smid;" : "=r"(ret) : );
 #endif
   return ret;

--- a/include/cutlass/arch/arch.h
+++ b/include/cutlass/arch/arch.h
@@ -52,7 +52,7 @@ int LaneId() {
   asm ("mov.u32 %0, %%laneid;" : "=r"(ret) : );
   return ret;
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
 }
 
@@ -64,7 +64,7 @@ int SmId() {
   asm ("mov.u32 %0, %%smid;" : "=r"(ret) : );
   return ret;
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
 }
 

--- a/include/cutlass/arch/arch.h
+++ b/include/cutlass/arch/arch.h
@@ -35,6 +35,7 @@
 #pragma once
 
 #include "cutlass/cutlass.h"
+#include "cutlass/platform/platform.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -51,7 +52,7 @@ int LaneId() {
   asm ("mov.u32 %0, %%laneid;" : "=r"(ret) : );
   return ret;
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_GCC_UNREACHABLE;
 #endif
 }
 
@@ -63,7 +64,7 @@ int SmId() {
   asm ("mov.u32 %0, %%smid;" : "=r"(ret) : );
   return ret;
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_GCC_UNREACHABLE;
 #endif
 }
 

--- a/include/cutlass/arch/arch.h
+++ b/include/cutlass/arch/arch.h
@@ -49,8 +49,10 @@ int LaneId() {
   int ret;
 #if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
   asm ("mov.u32 %0, %%laneid;" : "=r"(ret) : );
-#endif
   return ret;
+#else
+  CUTE_GCC_UNREACHABLE;
+#endif
 }
 
 /// Computes SM number the thread is running on
@@ -59,8 +61,10 @@ int SmId() {
   int ret;
 #if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
   asm ("mov.u32 %0, %%smid;" : "=r"(ret) : );
-#endif
   return ret;
+#else
+  CUTE_GCC_UNREACHABLE;
+#endif
 }
 
 #endif

--- a/include/cutlass/arch/arch.h
+++ b/include/cutlass/arch/arch.h
@@ -52,7 +52,7 @@ int LaneId() {
   asm ("mov.u32 %0, %%laneid;" : "=r"(ret) : );
   return ret;
 #else
-  CUTLASS_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
 }
 
@@ -64,7 +64,7 @@ int SmId() {
   asm ("mov.u32 %0, %%smid;" : "=r"(ret) : );
   return ret;
 #else
-  CUTLASS_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
 }
 

--- a/include/cutlass/arch/memory.h
+++ b/include/cutlass/arch/memory.h
@@ -108,6 +108,8 @@ struct global_load<AccessType,
         : "l"(ptr), "r"((int)pred_guard), "r"(data[0].x), "r"(data[0].y),
           "r"(data[0].z), "r"(data[0].w), "r"(data[1].x), "r"(data[1].y),
           "r"(data[1].z), "r"(data[1].w), "l"(((uint8_t *)ptr) + 16));
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
   }
 };
@@ -141,6 +143,8 @@ struct global_load<AccessType,
         : "l"(ptr), "r"((int)pred_guard), "r"(data[0].x), "r"(data[0].y),
           "r"(data[0].z), "r"(data[0].w), "r"(data[1].x), "r"(data[1].y),
           "r"(data[1].z), "r"(data[1].w), "l"(((uint8_t *)ptr) + 16));
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
   }
 };
@@ -170,6 +174,8 @@ struct global_load<AccessType,
         "}\n"
         : "=r"(data.x), "=r"(data.y), "=r"(data.z), "=r"(data.w)
         : "l"(ptr), "r"((int)pred_guard), "r"(data.x), "r"(data.y), "r"(data.z), "r"(data.w));
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
   }
 };
@@ -195,6 +201,8 @@ struct global_load<AccessType,
         "}\n"
         : "=r"(data.x), "=r"(data.y), "=r"(data.z), "=r"(data.w)
         : "l"(ptr), "r"((int)pred_guard), "r"(data.x), "r"(data.y), "r"(data.z), "r"(data.w));
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
   }
 };
@@ -222,6 +230,8 @@ struct global_load<AccessType,
         "}\n"
         : "=r"(data.x), "=r"(data.y)
         : "l"(ptr), "r"((int)pred_guard), "r"(data.x), "r"(data.y));
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
   }
 };
@@ -245,6 +255,8 @@ struct global_load<AccessType,
         "}\n"
         : "=r"(data.x), "=r"(data.y)
         : "l"(ptr), "r"((int)pred_guard), "r"(data.x), "r"(data.y));
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
   }
 };
@@ -271,6 +283,8 @@ struct global_load<AccessType,
         "}\n"
         : "=r"(data)
         : "l"(ptr), "r"((int)pred_guard), "r"(data));
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
   }
 };
@@ -293,6 +307,8 @@ struct global_load<AccessType,
         "}\n"
         : "=r"(data)
         : "l"(ptr), "r"((int)pred_guard), "r"(data));
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
   }
 };
@@ -319,6 +335,8 @@ struct global_load<AccessType,
         "}\n"
         : "=h"(data)
         : "l"(ptr), "r"((int)pred_guard), "h"(data));
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
   }
 };
@@ -341,6 +359,8 @@ struct global_load<AccessType,
         "}\n"
         : "=h"(data)
         : "l"(ptr), "r"((int)pred_guard), "h"(data));
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
   }
 };
@@ -396,6 +416,8 @@ struct global_store<AccessType, 64> {
         "r"(data[2].x), "r"(data[2].y), "r"(data[2].z), "r"(data[2].w),
         "l"(((uint8_t *)ptr) + 48),
         "r"(data[3].x), "r"(data[3].y), "r"(data[3].z), "r"(data[3].w));
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
   }
 };
@@ -418,6 +440,8 @@ struct global_store<AccessType, 32> {
       : "l"(ptr), "r"(data[0].x), "r"(data[0].y), "r"(data[0].z),
         "r"(data[0].w), "r"((int)pred_guard), "l"(((uint8_t *)ptr) + 16),
         "r"(data[1].x), "r"(data[1].y), "r"(data[1].z), "r"(data[1].w));
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
   }
 };
@@ -436,6 +460,8 @@ struct global_store<AccessType, 16> {
       "}\n"
       :
       : "l"(ptr), "r"(data.x), "r"(data.y), "r"(data.z), "r"(data.w), "r"((int)pred_guard));
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
   }
 };
@@ -454,6 +480,8 @@ struct global_store<AccessType, 8> {
       "}\n"
       :
       : "l"(ptr), "r"(data.x), "r"(data.y), "r"((int)pred_guard));
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
   }
 };
@@ -472,6 +500,8 @@ struct global_store<AccessType, 4> {
       "}\n"
       :
       : "l"(ptr), "r"(data), "r"((int)pred_guard));
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
   }
 };
@@ -490,6 +520,8 @@ struct global_store<AccessType, 2> {
       "}\n"
       :
       : "l"(ptr), "h"(data), "r"((int)pred_guard));
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
   }
 };
@@ -518,6 +550,8 @@ void shared_load<2>(void *dst, uint32_t ptr) {
   asm volatile("ld.shared.u16 %0, [%1];\n"
     : "=h"(*reinterpret_cast<uint16_t *>(dst))
     : "r"(ptr));
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
 }
 
@@ -529,6 +563,8 @@ void shared_load<4>(void *dst, uint32_t ptr) {
   asm volatile("ld.shared.u32 %0, [%1];\n"
     : "=r"(*reinterpret_cast<uint32_t *>(dst))
     : "r"(ptr));
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
 }
 
@@ -543,6 +579,8 @@ void shared_load<8>(void *dst, uint32_t ptr) {
       "=r"(dst_u64->x),
       "=r"(dst_u64->y)
     : "r"(ptr));
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
 }
 
@@ -559,6 +597,8 @@ void shared_load<16>(void *dst, uint32_t ptr) {
       "=r"(dst_u128->z),
       "=r"(dst_u128->w)
     : "r"(ptr));
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
 }
 
@@ -580,6 +620,8 @@ void shared_store<2>(uint32_t ptr, void const *src) {
     "r"(ptr),
     "h"(*reinterpret_cast<uint16_t const *>(src))
   );
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
 }
 
@@ -593,6 +635,8 @@ void shared_store<4>(uint32_t ptr, void const *src) {
     "r"(ptr),
     "r"(*reinterpret_cast<uint32_t const  *>(src))
   );
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
 }
 
@@ -608,6 +652,8 @@ void shared_store<8>(uint32_t ptr, void const *src) {
       "r"(dst_u64->x),
       "r"(dst_u64->y)
     );
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
 }
 
@@ -625,6 +671,8 @@ void shared_store<16>(uint32_t ptr, void const *src) {
       "r"(dst_u128->z),
       "r"(dst_u128->w)
     );
+#else
+  CUTE_GCC_UNREACHABLE;
 #endif
 }
 

--- a/include/cutlass/arch/memory.h
+++ b/include/cutlass/arch/memory.h
@@ -109,7 +109,8 @@ struct global_load<AccessType,
           "r"(data[0].z), "r"(data[0].w), "r"(data[1].x), "r"(data[1].y),
           "r"(data[1].z), "r"(data[1].w), "l"(((uint8_t *)ptr) + 16));
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -144,7 +145,8 @@ struct global_load<AccessType,
           "r"(data[0].z), "r"(data[0].w), "r"(data[1].x), "r"(data[1].y),
           "r"(data[1].z), "r"(data[1].w), "l"(((uint8_t *)ptr) + 16));
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -175,7 +177,8 @@ struct global_load<AccessType,
         : "=r"(data.x), "=r"(data.y), "=r"(data.z), "=r"(data.w)
         : "l"(ptr), "r"((int)pred_guard), "r"(data.x), "r"(data.y), "r"(data.z), "r"(data.w));
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -202,7 +205,8 @@ struct global_load<AccessType,
         : "=r"(data.x), "=r"(data.y), "=r"(data.z), "=r"(data.w)
         : "l"(ptr), "r"((int)pred_guard), "r"(data.x), "r"(data.y), "r"(data.z), "r"(data.w));
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -231,7 +235,8 @@ struct global_load<AccessType,
         : "=r"(data.x), "=r"(data.y)
         : "l"(ptr), "r"((int)pred_guard), "r"(data.x), "r"(data.y));
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -256,7 +261,8 @@ struct global_load<AccessType,
         : "=r"(data.x), "=r"(data.y)
         : "l"(ptr), "r"((int)pred_guard), "r"(data.x), "r"(data.y));
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -284,7 +290,8 @@ struct global_load<AccessType,
         : "=r"(data)
         : "l"(ptr), "r"((int)pred_guard), "r"(data));
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -308,7 +315,8 @@ struct global_load<AccessType,
         : "=r"(data)
         : "l"(ptr), "r"((int)pred_guard), "r"(data));
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -336,7 +344,8 @@ struct global_load<AccessType,
         : "=h"(data)
         : "l"(ptr), "r"((int)pred_guard), "h"(data));
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -360,7 +369,8 @@ struct global_load<AccessType,
         : "=h"(data)
         : "l"(ptr), "r"((int)pred_guard), "h"(data));
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -417,7 +427,8 @@ struct global_store<AccessType, 64> {
         "l"(((uint8_t *)ptr) + 48),
         "r"(data[3].x), "r"(data[3].y), "r"(data[3].z), "r"(data[3].w));
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -441,7 +452,8 @@ struct global_store<AccessType, 32> {
         "r"(data[0].w), "r"((int)pred_guard), "l"(((uint8_t *)ptr) + 16),
         "r"(data[1].x), "r"(data[1].y), "r"(data[1].z), "r"(data[1].w));
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -461,7 +473,8 @@ struct global_store<AccessType, 16> {
       :
       : "l"(ptr), "r"(data.x), "r"(data.y), "r"(data.z), "r"(data.w), "r"((int)pred_guard));
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -481,7 +494,8 @@ struct global_store<AccessType, 8> {
       :
       : "l"(ptr), "r"(data.x), "r"(data.y), "r"((int)pred_guard));
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -501,7 +515,8 @@ struct global_store<AccessType, 4> {
       :
       : "l"(ptr), "r"(data), "r"((int)pred_guard));
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -521,7 +536,8 @@ struct global_store<AccessType, 2> {
       :
       : "l"(ptr), "h"(data), "r"((int)pred_guard));
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -551,7 +567,8 @@ void shared_load<2>(void *dst, uint32_t ptr) {
     : "=h"(*reinterpret_cast<uint16_t *>(dst))
     : "r"(ptr));
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
 }
 
@@ -564,23 +581,8 @@ void shared_load<4>(void *dst, uint32_t ptr) {
     : "=r"(*reinterpret_cast<uint32_t *>(dst))
     : "r"(ptr));
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
-#endif
-}
-
-/// ld.shared - 64b
-template <>
-CUTLASS_DEVICE
-void shared_load<8>(void *dst, uint32_t ptr) {
-  uint2 *dst_u64 = reinterpret_cast<uint2 *>(dst);
-#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
-  asm volatile("ld.shared.v2.u32 {%0, %1}, [%2];\n"
-    :
-      "=r"(dst_u64->x),
-      "=r"(dst_u64->y)
-    : "r"(ptr));
-#else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
 }
 
@@ -598,7 +600,8 @@ void shared_load<16>(void *dst, uint32_t ptr) {
       "=r"(dst_u128->w)
     : "r"(ptr));
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
 }
 
@@ -621,7 +624,8 @@ void shared_store<2>(uint32_t ptr, void const *src) {
     "h"(*reinterpret_cast<uint16_t const *>(src))
   );
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
 }
 
@@ -636,7 +640,8 @@ void shared_store<4>(uint32_t ptr, void const *src) {
     "r"(*reinterpret_cast<uint32_t const  *>(src))
   );
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
 }
 
@@ -653,7 +658,8 @@ void shared_store<8>(uint32_t ptr, void const *src) {
       "r"(dst_u64->y)
     );
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
 }
 
@@ -672,7 +678,8 @@ void shared_store<16>(uint32_t ptr, void const *src) {
       "r"(dst_u128->w)
     );
 #else
-  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
 }
 

--- a/include/cutlass/arch/memory.h
+++ b/include/cutlass/arch/memory.h
@@ -109,7 +109,7 @@ struct global_load<AccessType,
           "r"(data[0].z), "r"(data[0].w), "r"(data[1].x), "r"(data[1].y),
           "r"(data[1].z), "r"(data[1].w), "l"(((uint8_t *)ptr) + 16));
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
   }
 };
@@ -144,7 +144,7 @@ struct global_load<AccessType,
           "r"(data[0].z), "r"(data[0].w), "r"(data[1].x), "r"(data[1].y),
           "r"(data[1].z), "r"(data[1].w), "l"(((uint8_t *)ptr) + 16));
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
   }
 };
@@ -175,7 +175,7 @@ struct global_load<AccessType,
         : "=r"(data.x), "=r"(data.y), "=r"(data.z), "=r"(data.w)
         : "l"(ptr), "r"((int)pred_guard), "r"(data.x), "r"(data.y), "r"(data.z), "r"(data.w));
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
   }
 };
@@ -202,7 +202,7 @@ struct global_load<AccessType,
         : "=r"(data.x), "=r"(data.y), "=r"(data.z), "=r"(data.w)
         : "l"(ptr), "r"((int)pred_guard), "r"(data.x), "r"(data.y), "r"(data.z), "r"(data.w));
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
   }
 };
@@ -231,7 +231,7 @@ struct global_load<AccessType,
         : "=r"(data.x), "=r"(data.y)
         : "l"(ptr), "r"((int)pred_guard), "r"(data.x), "r"(data.y));
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
   }
 };
@@ -256,7 +256,7 @@ struct global_load<AccessType,
         : "=r"(data.x), "=r"(data.y)
         : "l"(ptr), "r"((int)pred_guard), "r"(data.x), "r"(data.y));
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
   }
 };
@@ -284,7 +284,7 @@ struct global_load<AccessType,
         : "=r"(data)
         : "l"(ptr), "r"((int)pred_guard), "r"(data));
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
   }
 };
@@ -308,7 +308,7 @@ struct global_load<AccessType,
         : "=r"(data)
         : "l"(ptr), "r"((int)pred_guard), "r"(data));
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
   }
 };
@@ -336,7 +336,7 @@ struct global_load<AccessType,
         : "=h"(data)
         : "l"(ptr), "r"((int)pred_guard), "h"(data));
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
   }
 };
@@ -360,7 +360,7 @@ struct global_load<AccessType,
         : "=h"(data)
         : "l"(ptr), "r"((int)pred_guard), "h"(data));
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
   }
 };
@@ -417,7 +417,7 @@ struct global_store<AccessType, 64> {
         "l"(((uint8_t *)ptr) + 48),
         "r"(data[3].x), "r"(data[3].y), "r"(data[3].z), "r"(data[3].w));
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
   }
 };
@@ -441,7 +441,7 @@ struct global_store<AccessType, 32> {
         "r"(data[0].w), "r"((int)pred_guard), "l"(((uint8_t *)ptr) + 16),
         "r"(data[1].x), "r"(data[1].y), "r"(data[1].z), "r"(data[1].w));
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
   }
 };
@@ -461,7 +461,7 @@ struct global_store<AccessType, 16> {
       :
       : "l"(ptr), "r"(data.x), "r"(data.y), "r"(data.z), "r"(data.w), "r"((int)pred_guard));
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
   }
 };
@@ -481,7 +481,7 @@ struct global_store<AccessType, 8> {
       :
       : "l"(ptr), "r"(data.x), "r"(data.y), "r"((int)pred_guard));
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
   }
 };
@@ -501,7 +501,7 @@ struct global_store<AccessType, 4> {
       :
       : "l"(ptr), "r"(data), "r"((int)pred_guard));
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
   }
 };
@@ -521,7 +521,7 @@ struct global_store<AccessType, 2> {
       :
       : "l"(ptr), "h"(data), "r"((int)pred_guard));
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
   }
 };
@@ -551,7 +551,7 @@ void shared_load<2>(void *dst, uint32_t ptr) {
     : "=h"(*reinterpret_cast<uint16_t *>(dst))
     : "r"(ptr));
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
 }
 
@@ -564,7 +564,7 @@ void shared_load<4>(void *dst, uint32_t ptr) {
     : "=r"(*reinterpret_cast<uint32_t *>(dst))
     : "r"(ptr));
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
 }
 
@@ -580,7 +580,7 @@ void shared_load<8>(void *dst, uint32_t ptr) {
       "=r"(dst_u64->y)
     : "r"(ptr));
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
 }
 
@@ -598,7 +598,7 @@ void shared_load<16>(void *dst, uint32_t ptr) {
       "=r"(dst_u128->w)
     : "r"(ptr));
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
 }
 
@@ -621,7 +621,7 @@ void shared_store<2>(uint32_t ptr, void const *src) {
     "h"(*reinterpret_cast<uint16_t const *>(src))
   );
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
 }
 
@@ -636,7 +636,7 @@ void shared_store<4>(uint32_t ptr, void const *src) {
     "r"(*reinterpret_cast<uint32_t const  *>(src))
   );
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
 }
 
@@ -653,7 +653,7 @@ void shared_store<8>(uint32_t ptr, void const *src) {
       "r"(dst_u64->y)
     );
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
 }
 
@@ -672,7 +672,7 @@ void shared_store<16>(uint32_t ptr, void const *src) {
       "r"(dst_u128->w)
     );
 #else
-  CUTE_GCC_UNREACHABLE;
+  CUTLASS_SYCL_UNUSED;
 #endif
 }
 

--- a/include/cutlass/arch/memory.h
+++ b/include/cutlass/arch/memory.h
@@ -586,6 +586,23 @@ void shared_load<4>(void *dst, uint32_t ptr) {
 #endif
 }
 
+/// ld.shared - 64b
+template <>
+CUTLASS_DEVICE
+void shared_load<8>(void *dst, uint32_t ptr) {
+  uint2 *dst_u64 = reinterpret_cast<uint2 *>(dst);
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
+  asm volatile("ld.shared.v2.u32 {%0, %1}, [%2];\n"
+    :
+      "=r"(dst_u64->x),
+      "=r"(dst_u64->y)
+    : "r"(ptr));
+#else
+  CUTLASS_INVALID_CONTROL_PATH(
+      "Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
+#endif
+}
+
 /// ld.shared - 128b
 template <>
 CUTLASS_DEVICE

--- a/include/cutlass/arch/memory.h
+++ b/include/cutlass/arch/memory.h
@@ -109,7 +109,7 @@ struct global_load<AccessType,
           "r"(data[0].z), "r"(data[0].w), "r"(data[1].x), "r"(data[1].y),
           "r"(data[1].z), "r"(data[1].w), "l"(((uint8_t *)ptr) + 16));
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -144,7 +144,7 @@ struct global_load<AccessType,
           "r"(data[0].z), "r"(data[0].w), "r"(data[1].x), "r"(data[1].y),
           "r"(data[1].z), "r"(data[1].w), "l"(((uint8_t *)ptr) + 16));
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -175,7 +175,7 @@ struct global_load<AccessType,
         : "=r"(data.x), "=r"(data.y), "=r"(data.z), "=r"(data.w)
         : "l"(ptr), "r"((int)pred_guard), "r"(data.x), "r"(data.y), "r"(data.z), "r"(data.w));
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -202,7 +202,7 @@ struct global_load<AccessType,
         : "=r"(data.x), "=r"(data.y), "=r"(data.z), "=r"(data.w)
         : "l"(ptr), "r"((int)pred_guard), "r"(data.x), "r"(data.y), "r"(data.z), "r"(data.w));
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -231,7 +231,7 @@ struct global_load<AccessType,
         : "=r"(data.x), "=r"(data.y)
         : "l"(ptr), "r"((int)pred_guard), "r"(data.x), "r"(data.y));
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -256,7 +256,7 @@ struct global_load<AccessType,
         : "=r"(data.x), "=r"(data.y)
         : "l"(ptr), "r"((int)pred_guard), "r"(data.x), "r"(data.y));
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -284,7 +284,7 @@ struct global_load<AccessType,
         : "=r"(data)
         : "l"(ptr), "r"((int)pred_guard), "r"(data));
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -308,7 +308,7 @@ struct global_load<AccessType,
         : "=r"(data)
         : "l"(ptr), "r"((int)pred_guard), "r"(data));
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -336,7 +336,7 @@ struct global_load<AccessType,
         : "=h"(data)
         : "l"(ptr), "r"((int)pred_guard), "h"(data));
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -360,7 +360,7 @@ struct global_load<AccessType,
         : "=h"(data)
         : "l"(ptr), "r"((int)pred_guard), "h"(data));
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -417,7 +417,7 @@ struct global_store<AccessType, 64> {
         "l"(((uint8_t *)ptr) + 48),
         "r"(data[3].x), "r"(data[3].y), "r"(data[3].z), "r"(data[3].w));
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -441,7 +441,7 @@ struct global_store<AccessType, 32> {
         "r"(data[0].w), "r"((int)pred_guard), "l"(((uint8_t *)ptr) + 16),
         "r"(data[1].x), "r"(data[1].y), "r"(data[1].z), "r"(data[1].w));
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -461,7 +461,7 @@ struct global_store<AccessType, 16> {
       :
       : "l"(ptr), "r"(data.x), "r"(data.y), "r"(data.z), "r"(data.w), "r"((int)pred_guard));
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -481,7 +481,7 @@ struct global_store<AccessType, 8> {
       :
       : "l"(ptr), "r"(data.x), "r"(data.y), "r"((int)pred_guard));
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -501,7 +501,7 @@ struct global_store<AccessType, 4> {
       :
       : "l"(ptr), "r"(data), "r"((int)pred_guard));
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -521,7 +521,7 @@ struct global_store<AccessType, 2> {
       :
       : "l"(ptr), "h"(data), "r"((int)pred_guard));
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
   }
 };
@@ -551,7 +551,7 @@ void shared_load<2>(void *dst, uint32_t ptr) {
     : "=h"(*reinterpret_cast<uint16_t *>(dst))
     : "r"(ptr));
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
 }
 
@@ -564,7 +564,7 @@ void shared_load<4>(void *dst, uint32_t ptr) {
     : "=r"(*reinterpret_cast<uint32_t *>(dst))
     : "r"(ptr));
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
 }
 
@@ -580,7 +580,7 @@ void shared_load<8>(void *dst, uint32_t ptr) {
       "=r"(dst_u64->y)
     : "r"(ptr));
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
 }
 
@@ -598,7 +598,7 @@ void shared_load<16>(void *dst, uint32_t ptr) {
       "=r"(dst_u128->w)
     : "r"(ptr));
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
 }
 
@@ -621,7 +621,7 @@ void shared_store<2>(uint32_t ptr, void const *src) {
     "h"(*reinterpret_cast<uint16_t const *>(src))
   );
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
 }
 
@@ -636,7 +636,7 @@ void shared_store<4>(uint32_t ptr, void const *src) {
     "r"(*reinterpret_cast<uint32_t const  *>(src))
   );
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
 }
 
@@ -653,7 +653,7 @@ void shared_store<8>(uint32_t ptr, void const *src) {
       "r"(dst_u64->y)
     );
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
 }
 
@@ -672,7 +672,7 @@ void shared_store<16>(uint32_t ptr, void const *src) {
       "r"(dst_u128->w)
     );
 #else
-  CUTLASS_SYCL_UNUSED;
+  CUTLASS_INVALID_CONTROL_PATH("Attempting to use Nvidia-specific code path on non-Nvidia hardware.");
 #endif
 }
 

--- a/include/cutlass/arch/memory.h
+++ b/include/cutlass/arch/memory.h
@@ -82,7 +82,7 @@ struct global_load<AccessType,
   global_load(AccessType &D, void const *ptr, bool pred_guard) {
   uint4 *data = reinterpret_cast<uint4 *>(&D);
 
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
     asm volatile(
         "{\n"
         "  .reg .pred p;\n"
@@ -120,7 +120,7 @@ struct global_load<AccessType,
   CUTLASS_DEVICE
   global_load(AccessType &D, void const *ptr, bool pred_guard) {
   uint4 *data = reinterpret_cast<uint4 *>(&D);
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
     asm volatile(
         "{\n"
         "  .reg .pred p;\n"
@@ -153,7 +153,7 @@ struct global_load<AccessType,
   CUTLASS_DEVICE
   global_load(AccessType &D, void const *ptr, bool pred_guard) {
   uint4 &data = reinterpret_cast<uint4 &>(D);
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
     asm volatile(
         "{\n"
         "  .reg .pred p;\n"
@@ -182,7 +182,7 @@ struct global_load<AccessType,
   CUTLASS_DEVICE
   global_load(AccessType &D, void const *ptr, bool pred_guard) {
   uint4 &data = reinterpret_cast<uint4 &>(D);
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
     asm volatile(
         "{\n"
         "  .reg .pred p;\n"
@@ -207,7 +207,7 @@ struct global_load<AccessType,
   CUTLASS_DEVICE
   global_load(AccessType &D, void const *ptr, bool pred_guard) {
   uint2 &data = reinterpret_cast<uint2 &>(D);
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
     asm volatile(
         "{\n"
         "  .reg .pred p;\n"
@@ -234,7 +234,7 @@ struct global_load<AccessType,
   CUTLASS_DEVICE
   global_load(AccessType &D, void const *ptr, bool pred_guard) {
   uint2 &data = reinterpret_cast<uint2 &>(D);
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
     asm volatile(
         "{\n"
         "  .reg .pred p;\n"
@@ -257,7 +257,7 @@ struct global_load<AccessType,
   CUTLASS_DEVICE
   global_load(AccessType &D, void const *ptr, bool pred_guard) {
   unsigned &data = reinterpret_cast<unsigned &>(D);
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
     asm volatile(
         "{\n"
         "  .reg .pred p;\n"
@@ -283,7 +283,7 @@ struct global_load<AccessType,
   CUTLASS_DEVICE
   global_load(AccessType &D, void const *ptr, bool pred_guard) {
   unsigned &data = reinterpret_cast<unsigned &>(D);
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
     asm volatile(
         "{\n"
         "  .reg .pred p;\n"
@@ -305,7 +305,7 @@ struct global_load<AccessType,
   CUTLASS_DEVICE
   global_load(AccessType &D, void const *ptr, bool pred_guard) {
   uint16_t &data = reinterpret_cast<uint16_t &>(D);
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
     asm volatile(
         "{\n"
         "  .reg .pred p;\n"
@@ -331,7 +331,7 @@ struct global_load<AccessType,
   CUTLASS_DEVICE
   global_load(AccessType &D, void const *ptr, bool pred_guard) {
   uint16_t &data = reinterpret_cast<uint16_t &>(D);
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
     asm volatile(
         "{\n"
         "  .reg .pred p;\n"
@@ -378,7 +378,7 @@ struct global_store<AccessType, 64> {
   CUTLASS_DEVICE
   global_store(AccessType const &D, void *ptr, bool pred_guard) {
   uint4 const *data = reinterpret_cast<uint4 const *>(&D);
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
   asm volatile(
       "{\n"
       "  .reg .pred p;\n"
@@ -406,7 +406,7 @@ struct global_store<AccessType, 32> {
   CUTLASS_DEVICE
   global_store(AccessType const &D, void *ptr, bool pred_guard) {
   uint4 const *data = reinterpret_cast<uint4 const *>(&D);
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
   asm volatile(
       "{\n"
       "  .reg .pred p;\n"
@@ -427,7 +427,7 @@ struct global_store<AccessType, 16> {
   CUTLASS_DEVICE
   global_store(AccessType const &D, void *ptr, bool pred_guard) {
   uint4 const &data = reinterpret_cast<uint4 const &>(D);
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
   asm volatile(
       "{\n"
       "  .reg .pred p;\n"
@@ -445,7 +445,7 @@ struct global_store<AccessType, 8> {
   CUTLASS_DEVICE
   global_store(AccessType const &D, void *ptr, bool pred_guard) {
   uint2 const &data = reinterpret_cast<uint2 const &>(D);
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
   asm volatile(
       "{\n"
       "  .reg .pred p;\n"
@@ -463,7 +463,7 @@ struct global_store<AccessType, 4> {
   CUTLASS_DEVICE
   global_store(AccessType const &D, void *ptr, bool pred_guard) {
   uint32_t const &data = reinterpret_cast<uint32_t const &>(D);
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
     asm volatile(
       "{\n"
       "  .reg .pred p;\n"
@@ -481,7 +481,7 @@ struct global_store<AccessType, 2> {
   CUTLASS_DEVICE
   global_store(AccessType const &D, void *ptr, bool pred_guard) {
   uint16_t const &data = reinterpret_cast<uint16_t const &>(D);
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
   asm volatile(
       "{\n"
       "  .reg .pred p;\n"
@@ -514,7 +514,7 @@ void shared_load(void *dst, uint32_t ptr);
 template <>
 CUTLASS_DEVICE
 void shared_load<2>(void *dst, uint32_t ptr) {
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
   asm volatile("ld.shared.u16 %0, [%1];\n"
     : "=h"(*reinterpret_cast<uint16_t *>(dst))
     : "r"(ptr));
@@ -525,7 +525,7 @@ void shared_load<2>(void *dst, uint32_t ptr) {
 template <>
 CUTLASS_DEVICE
 void shared_load<4>(void *dst, uint32_t ptr) {
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
   asm volatile("ld.shared.u32 %0, [%1];\n"
     : "=r"(*reinterpret_cast<uint32_t *>(dst))
     : "r"(ptr));
@@ -537,7 +537,7 @@ template <>
 CUTLASS_DEVICE
 void shared_load<8>(void *dst, uint32_t ptr) {
   uint2 *dst_u64 = reinterpret_cast<uint2 *>(dst);
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
   asm volatile("ld.shared.v2.u32 {%0, %1}, [%2];\n"
     :
       "=r"(dst_u64->x),
@@ -551,7 +551,7 @@ template <>
 CUTLASS_DEVICE
 void shared_load<16>(void *dst, uint32_t ptr) {
   uint4 *dst_u128 = reinterpret_cast<uint4 *>(dst);
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
   asm volatile("ld.shared.v4.u32 {%0, %1, %2, %3}, [%4];\n"
     :
       "=r"(dst_u128->x),
@@ -574,7 +574,7 @@ void shared_store(uint32_t ptr, void const *src);
 template <>
 CUTLASS_DEVICE
 void shared_store<2>(uint32_t ptr, void const *src) {
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
   asm volatile("st.shared.u16 [%0], %1;\n"
     : :
     "r"(ptr),
@@ -587,7 +587,7 @@ void shared_store<2>(uint32_t ptr, void const *src) {
 template <>
 CUTLASS_DEVICE
 void shared_store<4>(uint32_t ptr, void const *src) {
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
   asm volatile("st.shared.u32 [%0], %1;\n"
     : :
     "r"(ptr),
@@ -601,7 +601,7 @@ template <>
 CUTLASS_DEVICE
 void shared_store<8>(uint32_t ptr, void const *src) {
   uint2 const *dst_u64 = reinterpret_cast<uint2 const *>(src);
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
   asm volatile("st.shared.v2.u32 [%0], {%1, %2};\n"
     : :
       "r"(ptr),
@@ -616,7 +616,7 @@ template <>
 CUTLASS_DEVICE
 void shared_store<16>(uint32_t ptr, void const *src) {
   uint4 const *dst_u128 = reinterpret_cast<uint4 const *>(src);
-#if !defined(CUTLASS_ENABLE_SYCL) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
   asm volatile("st.shared.v4.u32 [%0], {%1, %2, %3, %4};\n"
     : :
       "r"(ptr),

--- a/include/cutlass/platform/platform.h
+++ b/include/cutlass/platform/platform.h
@@ -160,6 +160,9 @@
 #  endif
 #endif
 
+#if !defined(CUTLASS_SYCL_UNUSED)
+#  define CUTLASS_SYCL_UNUSED assert(false); CUTLASS_GCC_UNREACHABLE
+#endif
 //-----------------------------------------------------------------------------
 // Keywords
 //-----------------------------------------------------------------------------

--- a/include/cutlass/platform/platform.h
+++ b/include/cutlass/platform/platform.h
@@ -160,8 +160,13 @@
 #  endif
 #endif
 
-#if !defined(CUTLASS_SYCL_UNUSED)
-#  define CUTLASS_SYCL_UNUSED assert(false); CUTLASS_GCC_UNREACHABLE
+// Fail and print a message. Typically used for notification of a compiler misconfiguration.
+#if defined(__CUDA_ARCH__)
+#  define CUTLASS_INVALID_CONTROL_PATH(x) assert(0 && x); printf(x); __brkpt()
+#elif defined(__has_builtin) && __has_builtin(__builtin_unreachable)
+#  define CUTLASS_INVALID_CONTROL_PATH(x) assert(0 && x); printf(x); __builtin_unreachable()
+#else
+#  define CUTLASS_INVALID_CONTROL_PATH(x) assert(0 && x); printf(x)
 #endif
 //-----------------------------------------------------------------------------
 // Keywords

--- a/include/cutlass/platform/platform.h
+++ b/include/cutlass/platform/platform.h
@@ -161,7 +161,7 @@
 #endif
 
 // Fail and print a message. Typically used for notification of a compiler misconfiguration.
-#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
+#if defined(__CUDA_ARCH__)
 #  define CUTLASS_INVALID_CONTROL_PATH(x) assert(0 && x); printf(x); __brkpt()
 #elif defined(__has_builtin) && __has_builtin(__builtin_unreachable)
 #  define CUTLASS_INVALID_CONTROL_PATH(x) assert(0 && x); printf(x); __builtin_unreachable()

--- a/include/cutlass/platform/platform.h
+++ b/include/cutlass/platform/platform.h
@@ -161,7 +161,7 @@
 #endif
 
 // Fail and print a message. Typically used for notification of a compiler misconfiguration.
-#if defined(__CUDA_ARCH__)
+#if defined(__CUDA_ARCH__) || defined(__SYCL_CUDA_ARCH__)
 #  define CUTLASS_INVALID_CONTROL_PATH(x) assert(0 && x); printf(x); __brkpt()
 #elif defined(__has_builtin) && __has_builtin(__builtin_unreachable)
 #  define CUTLASS_INVALID_CONTROL_PATH(x) assert(0 && x); printf(x); __builtin_unreachable()


### PR DESCRIPTION
- Suppress some spurious warnings using `CUTE_GCC_UNREACHABLE`
- Catch some potentially dangerous codepaths with same
- Improved ifdefs for CUDA arch specific stuff
- Remove an empty example file