### PR TITLE
Only enable example 14 when the backend is CUDA

### DIFF
--- a/examples/14_ampere_tf32_tensorop_gemm/CMakeLists.txt
+++ b/examples/14_ampere_tf32_tensorop_gemm/CMakeLists.txt
@@ -34,7 +34,9 @@ if (NOT CUTLASS_ENABLE_SYCL)
     )
 endif()
 
-cutlass_example_add_executable(
-  14_ampere_tf32_tensorop_gemm_cute
-  ampere_tf32_tensorop_gemm_cute.cu
-)
+if (SYCL_NVIDIA_TARGET)
+  cutlass_example_add_executable(
+    14_ampere_tf32_tensorop_gemm_cute
+    ampere_tf32_tensorop_gemm_cute.cu
+  )
+endif()


### PR DESCRIPTION
Maybe it was already broken, but the recent rebase for CUTLASS 3.6 introduced this line:

https://github.com/codeplaysoftware/cutlass-fork/blame/d49319f72cd9eeeb49830a94e23b3fdf8635fcc8/include/cutlass/gemm/device/gemm_universal_adapter.h#L461

Making use of `DispatchPolicy::SubgroupSize`. The example `examples/14_ampere_tf32_tensorop_gemm/ampere_tf32_tensorop_gemm_cute.cu` had set `DispatchPolicy` to 
```
using DispatchPolicy = cutlass::gemm::MainloopSm80CpAsync<PipelineStages>;
```

leading to this compiler error:
```
/tmp/finlay/cutlass-fork/include/cutlass/gemm/device/gemm_universal_adapter.h:461:70: error: no member named 'SubgroupSize' in 'cutlass::gemm::MainloopSm80CpAsync<4>'
  461 |           kernel_properties{sycl_exp::sub_group_size<DispatchPolicy::SubgroupSize>}
      |                                                      ~~~~~~~~~~~~~~~~^
```
I have modified the cmake to only enable that example for nvidia devices.
