### PR TITLE
Fix examples after file rename

### DIFF
--- a/examples/sycl/pvc/pvc_gemm_streamk.cpp
+++ b/examples/sycl/pvc/pvc_gemm_streamk.cpp
@@ -45,7 +45,7 @@
 #include "cutlass/util/packed_stride.hpp"
 #include "cutlass/util/reference/device/gemm_complex.h"
 #include "cutlass/util/reference/device/tensor_compare.h"
-#include "common.h"
+#include "common.hpp"
 
 #include "cutlass/gemm/kernel/xe_persistent_tile_scheduler_params_streamk.hpp"
 using namespace cute;

--- a/examples/sycl/pvc/pvc_gemm_with_epilogue_gelu.cpp
+++ b/examples/sycl/pvc/pvc_gemm_with_epilogue_gelu.cpp
@@ -49,7 +49,7 @@
 #include "cutlass/tensor_view.h"
 #include "cutlass/coord.h"
 
-#include "common.h"
+#include "common.hpp"
 
 using namespace cute;
 


### PR DESCRIPTION
common.h was moved to common.hpp with commit f14d683769d74a7311c560ce3a1dbbf3e58a0b31