### PR TITLE
Add check for system-installed oneMKL before downloading

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -65,9 +65,7 @@ function(cutlass_benchmark_add_executable NAME)
   )
 
   if (CUTLASS_ENABLE_SYCL)
-    add_dependencies(${NAME} onemkl_project)
-    target_include_directories(${NAME} PRIVATE ${ONEMKL_INCLUDE_DIR})
-    target_link_libraries(${NAME} PUBLIC ${ONEMKL_LIB})
+    add_onemkl_to_target(TARGET ${NAME})
     add_sycl_to_target(TARGET ${NAME})
   endif()
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -69,9 +69,7 @@ function(cutlass_example_add_executable NAME)
     )
 
   if (CUTLASS_ENABLE_SYCL)
-    add_dependencies(${NAME} onemkl_project)
-    target_include_directories(${NAME} PRIVATE ${ONEMKL_INCLUDE_DIR})
-    target_link_libraries(${NAME} PUBLIC ${ONEMKL_LIB})
+    add_onemkl_to_target(TARGET ${NAME})
     add_sycl_to_target(TARGET ${NAME})
   endif()
 


### PR DESCRIPTION
This PR introduces functionality to detect if oneMKL is already installed on the system and avoids downloading and installing it unnecessarily