### PR TITLE
Fix the TiledMma Permutation

### DIFF
--- a/examples/sycl/pvc/flash_attention_v2/pvc_flash_attn.cpp
+++ b/examples/sycl/pvc/flash_attention_v2/pvc_flash_attn.cpp
@@ -452,9 +452,11 @@ int main(int argc, const char** argv)
   // Workgroup-level tile
   using TileShape = Shape<_128, _64, _32>;
 
-  using TiledMma = TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-          Layout<Shape<_4, _2, _1>>,
-          Tile<_32, _32, _32>>; // Subgroup level-tile
+  using TiledMma =
+      TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
+               Layout<Shape<_4, _2, _1>>,
+               Tile<Layout<Shape<_8, _4, _4>, Stride<_1, _32, _8>>,
+                    Layout<Shape<_16, _2, _2>, Stride<_1, _32, _16>>, _32>>;
 
   constexpr int PipelineStages = 3;
   using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVC<PipelineStages>;

--- a/examples/sycl/pvc/pvc_gemm.cpp
+++ b/examples/sycl/pvc/pvc_gemm.cpp
@@ -318,9 +318,11 @@ int main(int argc, const char** argv)
   // Workgroup-level tile
   using TileShape = Shape<_256, _256, _32>;
 
-  using TiledMma = TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-          Layout<Shape<_8,_4,_1>>,
-          Tile<_64,_64,_32>>; // Subgroup level-tile
+  using TiledMma =
+      TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
+               Layout<Shape<_8, _4, _1>>,
+               Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
+                    Layout<Shape<_16, _4, _4>, Stride<_1, _64, _16>>, _32>>;
 
   constexpr int PipelineStages = 3;
   using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVC<PipelineStages>;

--- a/examples/sycl/pvc/pvc_gemm.cpp
+++ b/examples/sycl/pvc/pvc_gemm.cpp
@@ -318,6 +318,10 @@ int main(int argc, const char** argv)
   // Workgroup-level tile
   using TileShape = Shape<_256, _256, _32>;
 
+  // The Tile of this layout describes how 8x4x1 sub-groups tile the TileShape of <256, 256, 32>. 
+  // This permutation (which can be thought of as a scatter operation on the default tiling) 
+  // ensures that each sub-group operates on a contiguous 32x64x32 chunk (4x4x2 iterations)
+  // See 0t_mma_atom.md#TiledMMAs for more info.
   using TiledMma =
       TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
                Layout<Shape<_8, _4, _1>>,

--- a/examples/sycl/pvc/pvc_gemm_mixed_dtype.cpp
+++ b/examples/sycl/pvc/pvc_gemm_mixed_dtype.cpp
@@ -168,9 +168,11 @@ struct ExampleRunner {
     // Workgroup-level tile
     using TileShape = Shape<_256, _256, _32>;
 
-    using TiledMma = TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-            Layout<Shape<_8,_4,_1>>,
-            Tile<_64,_64,_32>>; // Subgroup level-tile
+    using TiledMma =
+      TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
+               Layout<Shape<_8, _4, _1>>,
+               Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
+                    Layout<Shape<_16, _4, _4>, Stride<_1, _64, _16>>, _32>>;
 
     constexpr int PipelineStages = 3;
     using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVC<PipelineStages>;

--- a/examples/sycl/pvc/pvc_gemm_streamk.cpp
+++ b/examples/sycl/pvc/pvc_gemm_streamk.cpp
@@ -352,9 +352,11 @@ int main(int argc, const char** argv)
   // Workgroup-level tile
   using TileShape = Shape<_256, _256, _32>;
 
-  using TiledMma = TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-          Layout<Shape<_8,_4,_1>>,
-          Tile<_64,_64,_32>>; // Subgroup level-tile
+  using TiledMma =
+      TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
+               Layout<Shape<_8, _4, _1>>,
+               Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
+                    Layout<Shape<_16, _4, _4>, Stride<_1, _64, _16>>, _32>>;
 
   constexpr int PipelineStages = 3;
   using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVC<PipelineStages>;

--- a/examples/sycl/pvc/pvc_gemm_with_epilogue_gelu.cpp
+++ b/examples/sycl/pvc/pvc_gemm_with_epilogue_gelu.cpp
@@ -329,7 +329,7 @@ int main(int argc, const char** argv)
       TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
                Layout<Shape<_8, _2, _1>>,
                Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
-                    Layout<Shape<_16, _2, _4>, Stride<_1, _64, _16>>, _32>>;
+                    Layout<Shape<_16, _2, _4>, Stride<_1, _64, _16>>, _16>>;
 
   constexpr int PipelineStages = 3;
   using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVC<PipelineStages>;

--- a/examples/sycl/pvc/pvc_gemm_with_epilogue_gelu.cpp
+++ b/examples/sycl/pvc/pvc_gemm_with_epilogue_gelu.cpp
@@ -325,9 +325,11 @@ int main(int argc, const char** argv)
   // Workgroup-level tile
   using TileShape = Shape<_256, _128, _16>;
 
-  using TiledMma = TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-          Layout<Shape<_8,_2,_1>>,
-          Tile<_64,_32,_16>>; // Subgroup level-tile
+  using TiledMma =
+      TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
+               Layout<Shape<_8, _2, _1>>,
+               Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
+                    Layout<Shape<_16, _2, _4>, Stride<_1, _64, _16>>, _32>>;
 
   constexpr int PipelineStages = 3;
   using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVC<PipelineStages>;

--- a/examples/sycl/pvc/pvc_gemm_with_epilogue_lincombdeeltact.cpp
+++ b/examples/sycl/pvc/pvc_gemm_with_epilogue_lincombdeeltact.cpp
@@ -371,9 +371,11 @@ int main(int argc, const char** argv)
   // Workgroup-level tile
   using TileShape = Shape<_256, _256, _32>;
 
-  using TiledMma = TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-          Layout<Shape<_8,_4,_1>>,
-          Tile<_64,_64,_32>>; // Subgroup level-tile
+  using TiledMma =
+      TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
+               Layout<Shape<_8, _4, _1>>,
+               Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
+                    Layout<Shape<_16, _4, _4>, Stride<_1, _64, _16>>, _32>>;
 
   constexpr int PipelineStages = 3;
   using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVC<PipelineStages>;

--- a/examples/sycl/pvc/pvc_gemm_with_epilogue_lincombdeeltact.cpp
+++ b/examples/sycl/pvc/pvc_gemm_with_epilogue_lincombdeeltact.cpp
@@ -375,7 +375,7 @@ int main(int argc, const char** argv)
       TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
                Layout<Shape<_8, _4, _1>>,
                Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
-                    Layout<Shape<_16, _4, _4>, Stride<_1, _64, _16>>, _32>>;
+                    Layout<Shape<_16, _4, _4>, Stride<_1, _64, _16>>, _16>>;
 
   constexpr int PipelineStages = 3;
   using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVC<PipelineStages>;

--- a/examples/sycl/pvc/pvc_gemm_with_epilogue_relu.cpp
+++ b/examples/sycl/pvc/pvc_gemm_with_epilogue_relu.cpp
@@ -329,7 +329,7 @@ int main(int argc, const char** argv)
       TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
                Layout<Shape<_8, _2, _1>>,
                Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
-                    Layout<Shape<_16, _2, _4>, Stride<_1, _64, _16>>, _32>>;
+                    Layout<Shape<_16, _2, _4>, Stride<_1, _64, _16>>, _16>>;
 
   constexpr int PipelineStages = 3;
   using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVC<PipelineStages>;

--- a/examples/sycl/pvc/pvc_gemm_with_epilogue_relu.cpp
+++ b/examples/sycl/pvc/pvc_gemm_with_epilogue_relu.cpp
@@ -325,9 +325,11 @@ int main(int argc, const char** argv)
   // Workgroup-level tile
   using TileShape = Shape<_256, _128, _16>;
 
-  using TiledMma = TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-          Layout<Shape<_8,_2,_1>>,
-          Tile<_64,_32,_16>>; // Subgroup level-tile
+  using TiledMma =
+      TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
+               Layout<Shape<_8, _2, _1>>,
+               Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
+                    Layout<Shape<_16, _2, _4>, Stride<_1, _64, _16>>, _32>>;
 
   constexpr int PipelineStages = 3;
   using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVC<PipelineStages>;

--- a/examples/sycl/pvc/pvc_gemm_with_per_row_bias.cpp
+++ b/examples/sycl/pvc/pvc_gemm_with_per_row_bias.cpp
@@ -346,7 +346,7 @@ int main(int argc, const char** argv)
       TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
                Layout<Shape<_8, _2, _1>>,
                Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
-                    Layout<Shape<_16, _2, _4>, Stride<_1, _64, _16>>, _32>>;
+                    Layout<Shape<_16, _2, _4>, Stride<_1, _64, _16>>, _16>>;
 
   constexpr int PipelineStages = 3;
   using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVC<PipelineStages>;

--- a/examples/sycl/pvc/pvc_gemm_with_per_row_bias.cpp
+++ b/examples/sycl/pvc/pvc_gemm_with_per_row_bias.cpp
@@ -342,9 +342,11 @@ int main(int argc, const char** argv)
   // Workgroup-level tile
   using TileShape = Shape<_256, _128, _16>;
 
-  using TiledMma = TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-          Layout<Shape<_8,_2,_1>>,
-          Tile<_64,_32,_16>>;  // Subgroup level-tile
+  using TiledMma =
+      TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
+               Layout<Shape<_8, _2, _1>>,
+               Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
+                    Layout<Shape<_16, _2, _4>, Stride<_1, _64, _16>>, _32>>;
 
   constexpr int PipelineStages = 3;
   using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVC<PipelineStages>;

--- a/include/cutlass/gemm/collective/builders/xe_mma_builder.inl
+++ b/include/cutlass/gemm/collective/builders/xe_mma_builder.inl
@@ -84,10 +84,12 @@ struct CollectiveBuilder<
       static_assert(cute::is_same_v<ElementAccumulator, float>, "Intel multi-stage pipeline requires ElementC to be of type float");
 
       //Prepare Template arguments required of CollectiveMainLoop
-      
-      using TiledMma = TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-          Layout<Shape<_8,_4,_1>>,
-          Tile<_64,_64,_32>>;
+
+      using TiledMma =
+          TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
+                   Layout<Shape<_8, _4, _1>>,
+                   Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
+                        Layout<Shape<_16, _4, _4>, Stride<_1, _64, _16>>, _32>>;
       
       static constexpr int PipelineStages = 3;
       using DispatchPolicy = cutlass::gemm::MainloopIntelPVC<PipelineStages>;

--- a/test/unit/gemm/device/gemm_universal_s8t_bf16n_f32t_mixed_input_tensor_op_f32_xe.cpp
+++ b/test/unit/gemm/device/gemm_universal_s8t_bf16n_f32t_mixed_input_tensor_op_f32_xe.cpp
@@ -82,9 +82,11 @@ TEST(XE_Device_GemmUniversal_s8t_bf16n_f32t_mixed_input_tensor_op_f32, 128x128x6
   // Workgroup-level tile
   using TileShape = Shape<_256, _256, _32>;
 
-  using TiledMma = TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-          Layout<Shape<_8,_4,_1>>,
-          Tile<_64,_64,_32>>; // Subgroup level-tile
+  using TiledMma =
+      TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
+               Layout<Shape<_8, _4, _1>>,
+               Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
+                    Layout<Shape<_16, _4, _4>, Stride<_1, _64, _16>>, _32>>;
 
   constexpr int PipelineStages = 3;
   using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVCMixedPrecision<PipelineStages>;


### PR DESCRIPTION
This PR modifies the permutation (3rd template argument) for all Xe `TiledMma` definitions, in a manner which properly defines the layout of the MMA atoms.

For example, the following defines a TiledMma which covers a CTATile of `<256, 256, 32>` using `8x4x1` sub-groups each executing an `8x16x16` MMA atom `4x4x2` times:
```cpp
  using TiledMma =
      TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
               Layout<Shape<_8, _4, _1>>,
               Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
                    Layout<Shape<_16, _4, _4>, Stride<_1, _64, _16>>, _32>>;
```
The permutation effectively describes a 'scatter permutation' on the original un-permuted layout, as described in [this section of the docs](https://github.com/NVIDIA/cutlass/blob/main/media/docs/cute/0t_mma_atom.md#tiledmmas). It describes the fact that **an individual sub-group operates on a contiguous chunk of 32x64x32**, as opposed to the default tiling which would have all sub-groups working *together* on a contiguous chunk before iterating to the next contiguous chunk.

On its own, this PR has no effect on correctness or performance of the Xe implementations, but it provides the opportunity to do things the *proper cutlass way*. In other words, we no longer need to consider that we operate at the 'sub-group level' because we have properly defined how a whole CTA/work-group works together to compute the MMA for its tile. We should be able to maintain a much smaller diff with equivalent implementations on other architectures, and avoid manually calculating things like 'sub-group coordinate/offset' etc.