### PR TITLE
Add sub-group stride to PVC TiledMma definitions

### DIFF
--- a/examples/sycl/pvc/flash_attention_v2/pvc_flash_attn.cpp
+++ b/examples/sycl/pvc/flash_attention_v2/pvc_flash_attn.cpp
@@ -454,7 +454,7 @@ int main(int argc, const char** argv)
 
   using TiledMma =
       TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-               Layout<Shape<_4, _2, _1>>,
+               Layout<Shape<_4, _2, _1>, Stride<_2, _1, _0>>,
                Tile<Layout<Shape<_8, _4, _4>, Stride<_1, _32, _8>>,
                     Layout<Shape<_16, _2, _2>, Stride<_1, _32, _16>>, _32>>;
 

--- a/examples/sycl/pvc/pvc_gemm.cpp
+++ b/examples/sycl/pvc/pvc_gemm.cpp
@@ -324,7 +324,7 @@ int main(int argc, const char** argv)
   // See 0t_mma_atom.md#TiledMMAs for more info.
   using TiledMma =
       TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-               Layout<Shape<_8, _4, _1>>,
+               Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>,
                Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
                     Layout<Shape<_16, _4, _4>, Stride<_1, _64, _16>>, _32>>;
 

--- a/examples/sycl/pvc/pvc_gemm_mixed_dtype.cpp
+++ b/examples/sycl/pvc/pvc_gemm_mixed_dtype.cpp
@@ -170,7 +170,7 @@ struct ExampleRunner {
 
     using TiledMma =
       TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-               Layout<Shape<_8, _4, _1>>,
+               Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>,
                Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
                     Layout<Shape<_16, _4, _4>, Stride<_1, _64, _16>>, _32>>;
 
@@ -385,9 +385,11 @@ int main(int argc, const char** argv)
   // Workgroup-level tile
   using TileShape = Shape<_256, _256, _32>;
 
-  using TiledMma = TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-          Layout<Shape<_8,_4,_1>>,
-          Tile<_64,_64,_32>>; // Subgroup level-tile
+  using TiledMma =
+    TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
+              Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>,
+              Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
+                  Layout<Shape<_16, _4, _4>, Stride<_1, _64, _16>>, _32>>;
 
   constexpr int PipelineStages = 3;
   using GEMMDispatchPolicy = cutlass::gemm::MainloopIntelPVCMixedPrecision<PipelineStages>;

--- a/examples/sycl/pvc/pvc_gemm_streamk.cpp
+++ b/examples/sycl/pvc/pvc_gemm_streamk.cpp
@@ -354,7 +354,7 @@ int main(int argc, const char** argv)
 
   using TiledMma =
       TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-               Layout<Shape<_8, _4, _1>>,
+               Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>,
                Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
                     Layout<Shape<_16, _4, _4>, Stride<_1, _64, _16>>, _32>>;
 

--- a/examples/sycl/pvc/pvc_gemm_with_epilogue_gelu.cpp
+++ b/examples/sycl/pvc/pvc_gemm_with_epilogue_gelu.cpp
@@ -327,7 +327,7 @@ int main(int argc, const char** argv)
 
   using TiledMma =
       TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-               Layout<Shape<_8, _2, _1>>,
+               Layout<Shape<_8, _2, _1>, Stride<_2, _1, _0>>,
                Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
                     Layout<Shape<_16, _2, _4>, Stride<_1, _64, _16>>, _16>>;
 

--- a/examples/sycl/pvc/pvc_gemm_with_epilogue_lincombdeeltact.cpp
+++ b/examples/sycl/pvc/pvc_gemm_with_epilogue_lincombdeeltact.cpp
@@ -373,7 +373,7 @@ int main(int argc, const char** argv)
 
   using TiledMma =
       TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-               Layout<Shape<_8, _4, _1>>,
+               Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>,
                Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
                     Layout<Shape<_16, _4, _4>, Stride<_1, _64, _16>>, _16>>;
 

--- a/examples/sycl/pvc/pvc_gemm_with_epilogue_relu.cpp
+++ b/examples/sycl/pvc/pvc_gemm_with_epilogue_relu.cpp
@@ -327,7 +327,7 @@ int main(int argc, const char** argv)
 
   using TiledMma =
       TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-               Layout<Shape<_8, _2, _1>>,
+               Layout<Shape<_8, _2, _1>, Stride<_2, _1, _0>>,
                Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
                     Layout<Shape<_16, _2, _4>, Stride<_1, _64, _16>>, _16>>;
 

--- a/examples/sycl/pvc/pvc_gemm_with_per_row_bias.cpp
+++ b/examples/sycl/pvc/pvc_gemm_with_per_row_bias.cpp
@@ -344,7 +344,7 @@ int main(int argc, const char** argv)
 
   using TiledMma =
       TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-               Layout<Shape<_8, _2, _1>>,
+               Layout<Shape<_8, _2, _1>, Stride<_2, _1, _0>>,
                Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
                     Layout<Shape<_16, _2, _4>, Stride<_1, _64, _16>>, _16>>;
 

--- a/include/cutlass/epilogue/collective/builders/xe_builder.inl
+++ b/include/cutlass/epilogue/collective/builders/xe_builder.inl
@@ -165,9 +165,12 @@ template <
       static_assert(is_static<TileShape_MNK>::value);
       static_assert(cute::is_same_v<ElementC, float>, "ElementC needs to be float for the Intel pipeline");
       
-      using TiledMma = TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-              Layout<Shape<_1,_1,_1>>,
-              Tile<_32,_64,_32>>;  // Subgroup level-tile
+      // Note, this must match the TiledMma definition in the GEMM builder
+      using TiledMma =
+          TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
+                   Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>,
+                   Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
+                        Layout<Shape<_16, _4, _4>, Stride<_1, _64, _16>>, _32>>;
       
       using DispatchPolicy = cutlass::epilogue::IntelPVCEpilogue;
       using CopyOpG2R = XE_2D_U32x8x16_LD_N;

--- a/include/cutlass/gemm/collective/builders/xe_mma_builder.inl
+++ b/include/cutlass/gemm/collective/builders/xe_mma_builder.inl
@@ -87,7 +87,7 @@ struct CollectiveBuilder<
 
       using TiledMma =
           TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-                   Layout<Shape<_8, _4, _1>>,
+                   Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>,
                    Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
                         Layout<Shape<_16, _4, _4>, Stride<_1, _64, _16>>, _32>>;
       

--- a/test/unit/gemm/device/gemm_universal_s8t_bf16n_f32t_mixed_input_tensor_op_f32_xe.cpp
+++ b/test/unit/gemm/device/gemm_universal_s8t_bf16n_f32t_mixed_input_tensor_op_f32_xe.cpp
@@ -84,7 +84,7 @@ TEST(XE_Device_GemmUniversal_s8t_bf16n_f32t_mixed_input_tensor_op_f32, 128x128x6
 
   using TiledMma =
       TiledMMA<MMA_Atom<XE_8x16x16_F32BF16BF16F32_TT>,
-               Layout<Shape<_8, _4, _1>>,
+               Layout<Shape<_8, _4, _1>, Stride<_4, _1, _0>>,
                Tile<Layout<Shape<_8, _8, _4>, Stride<_1, _32, _8>>,
                     Layout<Shape<_16, _4, _4>, Stride<_1, _64, _16>>, _32>>;
 


### PR DESCRIPTION
#194 fixed the MMA Atom permutation, but didn't update the sub-group stride which defines how the sub-groups are laid out. This PR adds this change. Thanks @t4c1 for suggestion!