### PR TITLE
Fix tensor initialisation

### DIFF
--- a/examples/sycl/pvc/common.hpp
+++ b/examples/sycl/pvc/common.hpp
@@ -56,5 +56,7 @@ bool initialize_block(
 
   cutlass::reference::device::BlockFillRandomUniform(
        block.get(), block.size(), seed, scope_max, scope_min, 0);
+
+  syclcompat::wait();
   return true;
 }

--- a/tools/util/include/cutlass/util/reference/device/sycl_tensor_fill.h
+++ b/tools/util/include/cutlass/util/reference/device/sycl_tensor_fill.h
@@ -126,7 +126,7 @@ struct RandomUniformFunc {
   CUTLASS_HOST_DEVICE
   Element operator()() {
     oneapi::mkl::rng::device::philox4x32x10<> generator(params.seed,
-      ThreadIdxX() + ThreadIdxX() + BlockIdxX() * BlockDimX());
+      ThreadIdxX() + BlockIdxX() * BlockDimX());
     FloatType rnd = oneapi::mkl::rng::device::generate(distribution, generator);
     
     // Random values are cast to integer after scaling by a power of two to facilitate error

--- a/tools/util/include/cutlass/util/reference/device/sycl_tensor_fill.h
+++ b/tools/util/include/cutlass/util/reference/device/sycl_tensor_fill.h
@@ -112,7 +112,6 @@ struct RandomUniformFunc {
 
   /// Parameters object
   Params params;
-  oneapi::mkl::rng::device::philox4x32x10<> generator;
   oneapi::mkl::rng::device::uniform<FloatType> distribution;
 
   //
@@ -121,12 +120,13 @@ struct RandomUniformFunc {
 
   explicit RandomUniformFunc(Params const &params):
       params(params),
-      generator(params.seed, ThreadIdxX() + BlockIdxX() * BlockDimX()),
       distribution(static_cast<FloatType>(params.min), static_cast<FloatType>(params.max)){}
 
   /// Compute random value and update RNG state
   CUTLASS_HOST_DEVICE
   Element operator()() {
+    oneapi::mkl::rng::device::philox4x32x10<> generator(params.seed,
+      ThreadIdxX() + ThreadIdxX() + BlockIdxX() * BlockDimX());
     FloatType rnd = oneapi::mkl::rng::device::generate(distribution, generator);
     
     // Random values are cast to integer after scaling by a power of two to facilitate error

--- a/tools/util/include/cutlass/util/reference/device/tensor_foreach.h
+++ b/tools/util/include/cutlass/util/reference/device/tensor_foreach.h
@@ -134,7 +134,7 @@ struct BlockForEach {
 #if defined (CUTLASS_ENABLE_SYCL)
       // TODO: query the queue for block size
       block_size = 128;
-      grid_size = (capacity + block_size - 1) / block_size;
+      grid_size = cute::ceil_div(capacity, block_size);
 #else
       // if grid_size or block_size are zero, query occupancy using the CUDA Occupancy API
       cudaError_t result = cudaOccupancyMaxPotentialBlockSize(


### PR DESCRIPTION
This PR fixes an issue with the on-device initialisation for tensors. It moves the generator inside the kernel so it can be initialised using the thread id. 