### PR TITLE
Add inline on for_each lambda function

### DIFF
--- a/include/cute/algorithm/tuple_algorithms.hpp
+++ b/include/cute/algorithm/tuple_algorithms.hpp
@@ -173,7 +173,8 @@ void
 for_each(T&& t, F&& f)
 {
   if constexpr (is_tuple<remove_cvref_t<T>>::value) {
-    return detail::apply(t, [&](auto&&... a) { (f(static_cast<decltype(a)&&>(a)), ...); }, tuple_seq<T>{});
+    return detail::apply(t,
+      [&](auto&&... a) { CUTE_INLINE_CALL (f(static_cast<decltype(a)&&>(a)), ...); }, tuple_seq<T>{});
   } else {
     return f(static_cast<T&&>(t));
   }

--- a/include/cute/config.hpp
+++ b/include/cute/config.hpp
@@ -34,14 +34,17 @@
 #  define CUTE_HOST_DEVICE __forceinline__ __host__ __device__
 #  define CUTE_DEVICE      __forceinline__          __device__
 #  define CUTE_HOST        __forceinline__ __host__
+#  define CUTE_INLINE_CALL
 #elif defined(__SYCL_DEVICE_ONLY__)
 #  define CUTE_HOST_DEVICE __attribute__((always_inline)) inline
 #  define CUTE_DEVICE      __attribute__((always_inline)) inline
 #  define CUTE_HOST        inline
+#  define CUTE_INLINE_CALL [[clang::always_inline]]
 #else
 #  define CUTE_HOST_DEVICE inline
 #  define CUTE_DEVICE      inline
 #  define CUTE_HOST        inline
+#  define CUTE_INLINE_CALL
 #endif // CUTE_HOST_DEVICE, CUTE_DEVICE
 
 #if defined(__CUDACC_RTC__)

--- a/include/cutlass/gemm/collective/sm80_mma_multistage.hpp
+++ b/include/cutlass/gemm/collective/sm80_mma_multistage.hpp
@@ -294,13 +294,8 @@ struct CollectiveMma<
     {
       // Pipeline the outer products with a static for loop.
       //
-#if defined(CUTLASS_ENABLE_SYCL)
-      CUTLASS_PRAGMA_UNROLL
-      for (auto k_block = 0; k_block < K_BLOCK_MAX; ++k_block)
-#else
       // Note, the for_each() function is required here to ensure `k_block` is of type Int<N>.
       for_each(make_int_sequence<K_BLOCK_MAX>{}, [&] (auto k_block)
-#endif
       {
         if (k_block == K_BLOCK_MAX - 1)
         {
@@ -340,9 +335,7 @@ struct CollectiveMma<
         // Thread-level register gemm for k_block
         cute::gemm(tiled_mma, accum, tCrA(_,_,k_block), tCrB(_,_,k_block), src_accum);
       }
-#if !defined(CUTLASS_ENABLE_SYCL)
       );
-#endif
     }
 
     cp_async_wait<0>();


### PR DESCRIPTION
This PR adds [[clang::always_inline]] on the for_each function and remove the workaround added for SYCL 