### PR TITLE
Enable merge queue workflow

### DIFF
--- a/.github/workflows/cuda_test.yml
+++ b/.github/workflows/cuda_test.yml
@@ -3,7 +3,7 @@ name: "Cuda Test"
 on:
   push:
     branches: [ "sycl-develop" ]
-  pull_request:
+  merge_group:
     branches: [ "sycl-develop" ]
   workflow_dispatch:
 

--- a/.github/workflows/intel_pvc_test.yml
+++ b/.github/workflows/intel_pvc_test.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "sycl-develop" ]
   pull_request:
     branches: [ "sycl-develop" ]
+  merge_group:
+    branches: [ "sycl-develop" ]
   workflow_dispatch:
     inputs:
       DPCPP_VERSION:

--- a/.github/workflows/intel_pvc_test.yml
+++ b/.github/workflows/intel_pvc_test.yml
@@ -1,4 +1,4 @@
-name: "Intel PVC Test"
+name: "SYCL Intel PVC Test"
 
 on:
   push:

--- a/.github/workflows/nvidia_test.yml
+++ b/.github/workflows/nvidia_test.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "sycl-develop" ]
   pull_request:
     branches: [ "sycl-develop" ]
+  merge_group:
+    branches: [ "sycl-develop" ]
   workflow_dispatch:
     inputs:
       DPCPP_VERSION:

--- a/.github/workflows/nvidia_test.yml
+++ b/.github/workflows/nvidia_test.yml
@@ -1,4 +1,4 @@
-name: "Test"
+name: "SYCL Nvidia Test"
 
 on:
   push:


### PR DESCRIPTION
This PR introduces the merge queue workflow and removes cuda tests from the PR workflow. Cuda tests can now be run manually in the PR, and they will automatically run in the merge queue. If any tests fail, the PR will not be merged.