### PR TITLE
Improve type cast for Flash Attention

### DIFF
--- a/examples/sycl/pvc/flash_attention_v2/pvc_flash_attn_mma.hpp
+++ b/examples/sycl/pvc/flash_attention_v2/pvc_flash_attn_mma.hpp
@@ -50,7 +50,6 @@ CUTLASS_DEVICE auto convert_type(Tensor<Engine, Layout> const &tensor) {
     using From_type = typename Engine::value_type;
     constexpr int numel = decltype(size(tensor))::value;
     cutlass::NumericArrayConverter<To_type, From_type, numel> convert_op;
-    // HACK: this requires tensor to be "contiguous"
     auto frag = convert_op(*reinterpret_cast<const cutlass::Array<From_type, numel> *>(tensor.data()));
     return make_tensor(make_rmem_ptr<To_type>(&frag), tensor.layout());
 }

--- a/examples/sycl/pvc/flash_attention_v2/pvc_flash_attn_mma.hpp
+++ b/examples/sycl/pvc/flash_attention_v2/pvc_flash_attn_mma.hpp
@@ -42,6 +42,21 @@
 
 namespace cutlass::gemm::collective {
 using namespace cute;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename To_type, typename Engine, typename Layout>
+CUTLASS_DEVICE auto convert_type(Tensor<Engine, Layout> const &tensor) {
+    using From_type = typename Engine::value_type;
+    constexpr int numel = decltype(size(tensor))::value;
+    cutlass::NumericArrayConverter<To_type, From_type, numel> convert_op;
+    // HACK: this requires tensor to be "contiguous"
+    auto frag = convert_op(*reinterpret_cast<const cutlass::Array<From_type, numel> *>(tensor.data()));
+    return make_tensor(make_rmem_ptr<To_type>(&frag), tensor.layout());
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <class DispatchPolicy, class TileShape_, class ElementQ_, class StrideQ_, class ElementK_, class StrideK_,
@@ -275,8 +290,8 @@ struct CollectiveMmaAttention<MainloopIntelPVC<Stages>, TileShape_, ElementQ_, S
     }
   }
 
-  template <class TileCoord, class FragAccum, class FragP, class TensorV, class FragSrc>
-  CUTLASS_DEVICE void mmaPV(TileCoord tile_coord, FragAccum &accum, FragP const &tPr, TensorV gB,
+  template <class TileCoord, class FragAccum, class FragS, class TensorV, class FragSrc>
+  CUTLASS_DEVICE void mmaPV(TileCoord tile_coord, FragAccum &accum, FragS const &tSr, TensorV gB,
                             FragSrc const &frag_src, int const &k_tile_count, int const &load_idx,
                             Params const &params) {
 
@@ -322,6 +337,9 @@ struct CollectiveMmaAttention<MainloopIntelPVC<Stages>, TileShape_, ElementQ_, S
       print("\n");
     }
 #endif
+
+    // 7) Convert S to P (FP32 -> BF16)
+    Tensor tPr = convert_type<typename TiledMma::ValTypeA>(tSr);
 
     //
     // Mainloop

--- a/examples/sycl/pvc/flash_attention_v2/pvc_flash_attn_ruuner.hpp
+++ b/examples/sycl/pvc/flash_attention_v2/pvc_flash_attn_ruuner.hpp
@@ -366,7 +366,7 @@ template <class GemmKernel> struct ExampleRunner {
                     (options.seq_len * options.head_size + options.seq_len * options.head_size) * 2 * 2 * (1e-9) /
                     (cute_time);
       std::cout << "Problem Size: " << options.batch << 'x' << options.num_heads << 'x' << options.seq_len << 'x'
-                << options.head_size;
+                << options.head_size << (options.is_causal ? "xCausal" : "xNonCausal");
       printf(":   %4.3f  GB/s   ,    %4.3f  TFlop/s   ,   %6.4f  ms\n", gbps, tflops, cute_time * 1000);
     }
 

--- a/include/cutlass/numeric_conversion.h
+++ b/include/cutlass/numeric_conversion.h
@@ -1068,7 +1068,7 @@ struct NumericArrayConverter<float, cutlass::half_t, N, Round> {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800) || defined (__SYCL_DEVICE_ONLY__)
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// Partial specialization for Array<cutlass::bfloat16_t, 2> <= Array<float, 2>, round to nearest
@@ -1084,17 +1084,7 @@ struct NumericArrayConverter<cutlass::bfloat16_t, float, 2, FloatRoundStyle::rou
 
     unsigned d;
 
-  #if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 800 || defined __SYCL_CUDA_ARCH__ && __SYCL_CUDA_ARCH__ >= 800
-
     asm("cvt.rn.bf16x2.f32 %0, %1, %2;\n" : "=r"(d) : "f"(source[1]), "f"(source[0]) );
-
-  #elif defined SYCL_INTEL_TARGET
-
-    auto out = __spirv_ConvertFToBF16INTEL(__ocl_vec_t<float, 2>{source[1], source[0]});
-    d = out.x;
-    d = (d << 16) | out.y;
-
-  #endif
 
     return reinterpret_cast<result_type const &>(d);
   }

--- a/include/cutlass/numeric_conversion.h
+++ b/include/cutlass/numeric_conversion.h
@@ -1068,7 +1068,7 @@ struct NumericArrayConverter<float, cutlass::half_t, N, Round> {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800) || defined (__SYCL_DEVICE_ONLY__)
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// Partial specialization for Array<cutlass::bfloat16_t, 2> <= Array<float, 2>, round to nearest
@@ -1084,7 +1084,17 @@ struct NumericArrayConverter<cutlass::bfloat16_t, float, 2, FloatRoundStyle::rou
 
     unsigned d;
 
+  #if defined __CUDA_ARCH__ && __CUDA_ARCH__ >= 800 || defined __SYCL_CUDA_ARCH__ && __SYCL_CUDA_ARCH__ >= 800
+
     asm("cvt.rn.bf16x2.f32 %0, %1, %2;\n" : "=r"(d) : "f"(source[1]), "f"(source[0]) );
+
+  #elif defined SYCL_INTEL_TARGET
+
+    auto out = __spirv_ConvertFToBF16INTEL(__ocl_vec_t<float, 2>{source[1], source[0]});
+    d = out.x;
+    d = (d << 16) | out.y;
+
+  #endif
 
     return reinterpret_cast<result_type const &>(d);
   }


### PR DESCRIPTION
This PR improves the type conversion from `fp32` to `bfloat16` for online softmax before calling the subsequent GEMM.