### PR TITLE
Build only the unit_test target for cuda

### DIFF
--- a/.github/workflows/cuda_test.yml
+++ b/.github/workflows/cuda_test.yml
@@ -31,7 +31,6 @@ jobs:
           nvidia-smi
           export CUDACXX=/usr/local/cuda/bin/nvcc
           cmake -G Ninja -DCUTLASS_NVCC_ARCHS="90a"
-          cmake --build . -j 48
 
       - name: Unit test
         shell: bash


### PR DESCRIPTION
This PR modifies the cuda build to include only the unit_tests target reducing build time.