### PR TITLE
Add workflow for Python Interface tests

### DIFF
--- a/.github/actions/install-dpcpp/action.yml
+++ b/.github/actions/install-dpcpp/action.yml
@@ -1,0 +1,34 @@
+name: install-dpcpp
+description: Download and unpack DPC++ nightly release
+inputs:
+  DPCPP_VERSION:
+    description: "DPC++ version to use"
+    type: string
+  DPCPP_PATH:
+    description: Path to DPC++
+    type: string
+runs:
+  using: "composite"
+  steps:
+    - name: Install DPCPP
+      id: install_dpcpp
+      shell: bash
+      run: |
+        export DPCPP_PATH=${{ inputs.DPCPP_PATH }}
+        mkdir $DPCPP_PATH
+        pushd $DPCPP_PATH
+        if [[ "${{ inputs.DPCPP_VERSION }}" != "" ]]; then \
+          echo "Will use DPCPP ${{ inputs.DPCPP_VERSION }}."; \
+          echo "Downloading DPCPP from https://github.com/intel/llvm/releases/download/${{ inputs.DPCPP_VERSION }}/sycl_linux.tar.gz"; \
+          wget -q https://github.com/intel/llvm/releases/download/${{ inputs.DPCPP_VERSION }}/sycl_linux.tar.gz; \
+        else
+          echo "Will use latest DPCPP version."; \
+          latest=$(curl -sS https://api.github.com/repos/intel/llvm/releases | jq -r '[.[].tag_name|select(match("nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}"))][0]') && \
+          echo "Downloading DPCPP from https://github.com/intel/llvm/releases/download/${latest}/sycl_linux.tar.gz"; \
+          wget -q https://github.com/intel/llvm/releases/download/${latest}/sycl_linux.tar.gz; \
+        fi
+        tar -xf sycl_linux.tar.gz
+        rm sycl_linux.tar.gz
+        popd
+
+

--- a/.github/actions/install-dpctl/action.yml
+++ b/.github/actions/install-dpctl/action.yml
@@ -1,0 +1,32 @@
+name: install-dpctl
+description: Clone and build DPCTL
+inputs:
+  DPCTL_URL:
+    description: URL of the DPCTL repository to use.
+  DPCTL_BRANCH:
+    description: Name of the DPCTL branch to use.
+  DPCTL_PATH:
+    description: Path where to put DPCTL
+  DPCPP_PATH:
+    description: Path to DPC++
+  VENV_PATH:
+    description: Path to virtualenv
+
+runs:
+  using: "composite"
+  steps:
+    - name: Clone and install DPCTL
+      shell: bash
+      run: |
+        export DPCTL_PATH=${{ inputs.DPCTL_PATH }}
+        git clone --depth=1 --branch ${{ inputs.DPCTL_BRANCH }} ${{ inputs.DPCTL_URL }} $DPCTL_PATH
+        pushd $DPCTL_PATH
+        source ${{ inputs.VENV_PATH }}/bin/activate
+        export DPCPP_PATH=${{ inputs.DPCPP_PATH }}
+        export PATH=$DPCPP_PATH/bin:$PATH
+        export LD_LIBRARY_PATH=$DPCPP_PATH/lib:$LD_LIBRARY_PATH
+        pip install --no-cache-dir numpy cython scikit-build cmake ninja pytest versioneer
+        python scripts/build_locally.py --c-compiler=$DPCPP_PATH/bin/clang \
+          --cxx-compiler=$DPCPP_PATH/bin/clang++ \
+          --compiler-root=$DPCPP_PATH/bin \
+          --cmake-opts="-DCMAKE_INCLUDE_PATH=/lib/x86_64-linux-gnu"

--- a/.github/workflows/intel_pvc_python_test.yml
+++ b/.github/workflows/intel_pvc_python_test.yml
@@ -1,0 +1,69 @@
+name: "SYCL Intel PVC Python Interface Test"
+
+on:
+  push:
+    branches: [ "sycl-develop" ]
+  pull_request:
+    branches: [ "sycl-develop" ]
+  merge_group:
+    branches: [ "sycl-develop" ]
+  workflow_dispatch:
+    inputs:
+      DPCPP_VERSION:
+        description: "DPCPP version to use"
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run-tests:
+    name: Run Intel PVC tests
+    runs-on: cp-gpumax-1100-gpu
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install DPC++
+        id: install_dpcpp
+        uses: ./.github/actions/install-dpcpp
+        with:
+          DPCPP_VERSION: ${{ inputs.DPCPP_VERSION }}
+          DPCPP_PATH: ~/dpcpp
+      - name: Setup virtual environment
+        shell: bash
+        run: |
+          python3 -m venv ~/.venv
+      - name: Install DPCTL
+        id: install_dpctl
+        uses: ./.github/actions/install-dpctl
+        with:
+          DPCTL_URL: https://github.com/sommerlukas/dpctl.git
+          DPCTL_BRANCH: additional-kernel-param-types
+          DPCTL_PATH: ~/dpctl
+          DPCPP_PATH: ~/dpcpp
+          VENV_PATH: ~/.venv
+      - name: Install Torch XPU
+        shell: bash
+        run: |
+          source ~/.venv/bin/activate
+          pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/test/xpu
+          pip uninstall --yes intel-sycl-rt intel-cmplr-lib-ur umf
+      - name: Run Python Interface GEMM Tests
+        shell: bash
+        run: |
+          export DPCPP_PATH=~/dpcpp
+          export PATH=$DPCPP_PATH/bin:$PATH
+          export LD_LIBRARY_PATH=$DPCPP_PATH/lib:$LD_LIBRARY_PATH
+          source ~/.venv/bin/activate
+          pip install -e .
+          export CUTLASS_USE_SYCL=1
+          python test/python/cutlass/gemm/run_all_tests.py

--- a/.github/workflows/intel_pvc_test.yml
+++ b/.github/workflows/intel_pvc_test.yml
@@ -28,34 +28,22 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-
-      - name: Install dependencies
-        shell: bash
-        run: |
-          mkdir ~/dpcpp
-          pushd ~/dpcpp
-          echo "Will use DPCPP ${{ inputs.DPCPP_VERSION }}."
-          if [[ "${{ inputs.DPCPP_VERSION }}" != "" ]]; then \
-            echo "Downloading DPCPP from https://github.com/intel/llvm/releases/download/${{ inputs.DPCPP_VERSION }}/sycl_linux.tar.gz"; \
-            wget -q https://github.com/intel/llvm/releases/download/${{ inputs.DPCPP_VERSION }}/sycl_linux.tar.gz; \
-          else
-            latest=$(curl -sS https://api.github.com/repos/intel/llvm/releases | jq -r '[.[].tag_name|select(match("nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}"))][0]') && \
-            echo "Downloading DPCPP from https://github.com/intel/llvm/releases/download/${latest}/sycl_linux.tar.gz"; \
-            wget -q https://github.com/intel/llvm/releases/download/${latest}/sycl_linux.tar.gz; \
-          fi
-          tar -xf sycl_linux.tar.gz
-          rm sycl_linux.tar.gz
-          popd
-
       # For a specific DPC++ nightly build define the repository variable DPCPP_VERSION
       # for example using the tag: 'nightly-2024-04-22'
+      - name: Install DPC++
+        id: install_dpcpp
+        uses: ./.github/actions/install-dpcpp
+        with:
+          DPCPP_VERSION: ${{ inputs.DPCPP_VERSION }}
+          DPCPP_PATH: ~/dpcpp
       - name: Build
         shell: bash
         run: |
-          export PATH=~/dpcpp/bin/:$PATH
-          export C_INCLUDE_PATH=~/dpcpp/include/:$C_INCLUDE_PATH
-          export CPLUS_INCLUDE_PATH=~/dpcpp/include/:$CPLUS_INCLUDE_PATH
-          export LD_LIBRARY_PATH=~/dpcpp/lib/:$LD_LIBRARY_PATH
+          export DPCPP_PATH=~/dpcpp
+          export PATH=$DPCPP_PATH/bin/:$PATH
+          export C_INCLUDE_PATH=$DPCPP_PATH/include/:$C_INCLUDE_PATH
+          export CPLUS_INCLUDE_PATH=$DPCPP_PATH/include/:$CPLUS_INCLUDE_PATH
+          export LD_LIBRARY_PATH=$DPCPP_PATH/lib/:$LD_LIBRARY_PATH
           export CC=clang
           export CXX=clang++
           clang++ --version
@@ -67,11 +55,13 @@ jobs:
       - name: Unit test
         shell: bash
         run: |
-          export LD_LIBRARY_PATH=~/dpcpp/lib/:$LD_LIBRARY_PATH
+          export DPCPP_PATH=~/dpcpp
+          export LD_LIBRARY_PATH=$DPCPP_PATH/lib/:$LD_LIBRARY_PATH
           cmake --build . --target test_unit -j 24
 
       - name: Examples
         shell: bash
         run: |
-          export LD_LIBRARY_PATH=~/dpcpp/lib/:$LD_LIBRARY_PATH
+          export DPCPP_PATH=~/dpcpp
+          export LD_LIBRARY_PATH=$DPCPP_PATH/lib/:$LD_LIBRARY_PATH
           cmake --build . --target test_examples -j 24

--- a/python/cutlass/backend/compiler.py
+++ b/python/cutlass/backend/compiler.py
@@ -165,6 +165,7 @@ class ArtifactManager:
                                        "-DSYCL_INTEL_TARGET",
                                        "-shared", "-fPIC",
                                        "-fno-sycl-dead-args-optimization",
+                                       "-Xspirv-translator -spirv-ext=+SPV_INTEL_split_barrier",
                                        "-fsycl-range-rounding=disable"]
         self.nvcc()
         self.compiled_cache_device = {}


### PR DESCRIPTION
Add a workflow to run the Python Interface tests on PVC.

Extract the steps to install DPC++ nightly from the existing workflow into a reusable action.