### PR TITLE
Replace removed bfloat16ToBits with bit_cast

### DIFF
--- a/include/cutlass/bfloat16.h
+++ b/include/cutlass/bfloat16.h
@@ -126,7 +126,7 @@ public:
 
     #elif defined(CUTLASS_ENABLE_SYCL)
 
-    storage = sycl::ext::oneapi::detail::bfloat16ToBits(sycl::ext::oneapi::bfloat16(x));
+    storage = bit_cast<decltype(storage)>(sycl::ext::oneapi::bfloat16(x));
 
     #else
     uint32_t bits;

--- a/include/cutlass/bfloat16.h
+++ b/include/cutlass/bfloat16.h
@@ -126,7 +126,7 @@ public:
 
     #elif defined(CUTLASS_ENABLE_SYCL)
 
-    storage = bit_cast<decltype(storage)>(sycl::ext::oneapi::bfloat16(x));
+    storage = std::bit_cast<decltype(storage)>(sycl::ext::oneapi::bfloat16(x));
 
     #else
     uint32_t bits;

--- a/include/cutlass/bfloat16.h
+++ b/include/cutlass/bfloat16.h
@@ -126,7 +126,7 @@ public:
 
     #elif defined(CUTLASS_ENABLE_SYCL)
 
-    storage = std::bit_cast<decltype(storage)>(sycl::ext::oneapi::bfloat16(x));
+    storage = cutlass::platform::bit_cast<decltype(storage)>(sycl::ext::oneapi::bfloat16(x));
 
     #else
     uint32_t bits;


### PR DESCRIPTION
`bfloat16toBits` was removed in [DPC++](https://github.com/intel/llvm/pull/17256) to be replaced with `bit_cast`. Should fix CI failures described [here](https://github.com/codeplaysoftware/cutlass-fork/pull/239#issuecomment-2692086933).