### PR TITLE
Workaround DPCTL Level Zero issue

### DIFF
--- a/.github/actions/install-dpctl/action.yml
+++ b/.github/actions/install-dpctl/action.yml
@@ -29,4 +29,4 @@ runs:
         python scripts/build_locally.py --c-compiler=$DPCPP_PATH/bin/clang \
           --cxx-compiler=$DPCPP_PATH/bin/clang++ \
           --compiler-root=$DPCPP_PATH/bin \
-          --cmake-opts="-DCMAKE_INCLUDE_PATH=/lib/x86_64-linux-gnu"
+          --cmake-opts="-DCMAKE_INCLUDE_PATH=/lib/x86_64-linux-gnu -DLIBZE_LOADER_FILENAME=libze_loader.so.1"

--- a/.github/workflows/intel_pvc_python_test.yml
+++ b/.github/workflows/intel_pvc_python_test.yml
@@ -47,7 +47,7 @@ jobs:
         uses: ./.github/actions/install-dpctl
         with:
           DPCTL_URL: https://github.com/sommerlukas/dpctl.git
-          DPCTL_BRANCH: additional-kernel-param-types
+          DPCTL_BRANCH: rebase-kernel-param
           DPCTL_PATH: ~/dpctl
           DPCPP_PATH: ~/dpcpp
           VENV_PATH: ~/.venv


### PR DESCRIPTION
The static linking of the Level Zero loader into the Level Zero adapter in https://github.com/intel/llvm/pull/17104 causes DPCTL's logic to detect the name of the Level Zero loader library to fail: https://github.com/IntelPython/dpctl/issues/2022

This in turn causes the creation of a SYCL `kernel_bundle` from SPIR-V in the Python interface to fail and leads to CI failures on unrelated branches. 

This PR brings a workaround for this issue, by using a CMake fix for DPCTL.