### PR TITLE
Fix link to SYCL build documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ _CUTLASS 3.8.0 - January 2025_
 **This repository fast-follows NVIDIA CUTLASS repository adding SYCL support for Intel GPUs.**
   The CUDA support is unmodified from upstream and can be used interchangeably.
 **
-**For SYCL support instructions, refer to the [SYCL build documentation](./media/docs/build/build/building_with_sycl_support.md)**
+**For SYCL support instructions, refer to the [SYCL build documentation](./media/docs/build/building_with_sycl_support.md)**
 
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/codeplaysoftware/cutlass-fork/badge)](https://scorecard.dev/viewer/?uri=github.com/codeplaysoftware/cutlass-fork)
 


### PR DESCRIPTION
This PR fix the link to the SYCL build documentation in the README