### PR TITLE
Fix grid_shape calculation for Tile Schedulers

### DIFF
--- a/examples/sycl/pvc/pvc_gemm_persistent.cpp
+++ b/examples/sycl/pvc/pvc_gemm_persistent.cpp
@@ -226,7 +226,7 @@ struct ExampleRunner {
       {block_A.get(), stride_A, block_B.get(), stride_B},
       {{options.alpha, options.beta}, block_C.get(), stride_C, block_D.get(), stride_D},
       hw_info,
-      {1, RasterOrderOptions::AlongM}
+      {1, RasterOrderOptions::AlongN}
     };
 
     Gemm gemm_op;

--- a/include/cutlass/gemm/kernel/tile_scheduler.hpp
+++ b/include/cutlass/gemm/kernel/tile_scheduler.hpp
@@ -144,15 +144,17 @@ struct TileSchedulerSelector<
 #if defined (SYCL_INTEL_TARGET)
 template <
   class TileShape,
-  class ClusterShape
+  class ClusterShape,
+  uint32_t ThreadsPerBlock
 >
 struct TileSchedulerSelector<
   StreamKScheduler,
   arch::IntelPVC,
   TileShape,
-  ClusterShape
+  ClusterShape,
+  ThreadsPerBlock
   > {
-  using Scheduler = PersistentTileSchedulerXeStreamK<TileShape>;
+  using Scheduler = PersistentTileSchedulerXeStreamK<TileShape, ThreadsPerBlock>;
 };
 
 template <

--- a/include/cutlass/gemm/kernel/xe_persistent_tile_scheduler_params_streamk.hpp
+++ b/include/cutlass/gemm/kernel/xe_persistent_tile_scheduler_params_streamk.hpp
@@ -380,7 +380,7 @@ struct PersistentTileSchedulerXeStreamKParams {
     KernelHardwareInfo hw_info,
     bool truncate_range = true
   ) {
-    uint32_t available_sms = hw_info.sm_count / 8;
+    uint32_t available_sms = hw_info.sm_count;
     auto possibly_truncate = [&](int x, int y) {
       if(truncate_range)
         return static_cast<unsigned int>(platform::min(x, y));

--- a/include/cutlass/gemm/kernel/xe_tile_scheduler_streamk.hpp
+++ b/include/cutlass/gemm/kernel/xe_tile_scheduler_streamk.hpp
@@ -44,7 +44,8 @@ namespace cutlass::gemm::kernel::detail {
 
 // Persistent Thread Block (TB) scheduler leveraging stream-K decomposition
 template <
-  class TileShape
+  class TileShape,
+  uint32_t ThreadsPerBlock
 >
 class PersistentTileSchedulerXeStreamK {
   //
@@ -290,7 +291,7 @@ public:
   }
 
   // Performs the reduction across splits for a given output tile.
-template <int ThreadsPerBlock, class FrgTensorC>
+template <class FrgTensorC>
   CUTLASS_DEVICE
   static void
   fixup(
@@ -302,12 +303,12 @@ template <int ThreadsPerBlock, class FrgTensorC>
     static constexpr uint32_t Offset = static_cast<int>(cutlass::arch::ReservedNamedBarriers::StreamkBarrier0);
     static constexpr uint32_t MaxNumNamedBarriers = 1;
     using BarrierManager = NamedBarrierManager<ThreadsPerBlock, Offset, MaxNumNamedBarriers>;
-    return fixup_helper<ThreadsPerBlock, FrgTensorC, BarrierManager>(
+    return fixup_helper<FrgTensorC, BarrierManager>(
       params, work_tile_info, accumulators, num_barriers, barrier_idx);
   }
 
   // Helper for performing the reduction across splits for a given output tile.
-  template <int ThreadsPerBlock, class FrgTensorC, class BarrierManager>
+  template <class FrgTensorC, class BarrierManager>
   CUTLASS_DEVICE
   static void
   fixup_helper(

--- a/include/cutlass/kernel_hardware_info.h
+++ b/include/cutlass/kernel_hardware_info.h
@@ -62,8 +62,14 @@ struct KernelHardwareInfo {
   static inline int
   query_device_multiprocessor_count(int device_id = 0) {
     auto queue = syclcompat::get_default_queue();
-    auto device = queue.get_device();
-    int multiprocessor_count = static_cast<int>(device.get_info<sycl::ext::oneapi::info::device::num_compute_units>());
+    auto dev = queue.get_device();
+    int multiprocessor_count = 1;
+    //TODO (Codeplay): Replace with device.get_info<sycl::ext::oneapi::info::device::num_compute_units>() once available 
+#if defined __SYCL_CUDA_ARCH__
+    multiprocessor_count = dev.get_info<sycl::info::device::max_compute_units>();
+#elif defined SYCL_INTEL_TARGET
+    multiprocessor_count = static_cast<int>(dev.get_info<sycl::ext::intel::info::device::gpu_slices>() * dev.get_info<sycl::ext::intel::info::device::gpu_subslices_per_slice>());
+#endif
     return multiprocessor_count;
   }
 

--- a/include/cutlass/kernel_hardware_info.h
+++ b/include/cutlass/kernel_hardware_info.h
@@ -61,8 +61,9 @@ struct KernelHardwareInfo {
 #if defined (CUTLASS_ENABLE_SYCL)
   static inline int
   query_device_multiprocessor_count(int device_id = 0) {
-    syclcompat::device_ext& dev = syclcompat::get_device(device_id);
-    int multiprocessor_count = dev.get_max_compute_units();
+    auto queue = syclcompat::get_default_queue();
+    auto device = queue.get_device();
+    int multiprocessor_count = static_cast<int>(device.get_info<sycl::ext::oneapi::info::device::num_compute_units>());
     return multiprocessor_count;
   }
 


### PR DESCRIPTION
This PR fixes the `grid_shape` calculation for `PersistentSchedulerXe`. The `grid_shape` calculation is supposed to be limited by the `sm_count`, however, for Intel hardware the closest match to an `sm` is an `Xe_Core`. The call to `max_compute_units()` in this file ([link](https://github.com/codeplaysoftware/cutlass-fork/blob/7d19654b72fcbb13019aed502a7772bc25be9b30/include/cutlass/kernel_hardware_info.h#L65)) returns the total Execution Unit (EU) count for the hardware, so we need to convert that to `Xe_Core` count by dividing the `EU` count by `8`(this number was taken from the [oneAPI Optimization Guide](https://www.intel.com/content/www/us/en/docs/oneapi/optimization-guide-gpu/2025-0/intel-xe-gpu-architecture.html)).

**Note**: the following code is running on Intel Data Center GPU Max 1100 (with EU count 448).

Before the fix:
```
$ ./examples/sycl/pvc/pvc_gemm_persistent --iterations=0
Running GEMM with Normal schedule
grid.x: 20 | grid.y: 16 | grid.z: 1
Disposition: Passed

Running GEMM with Cooperative schedule
grid.x: 320 | grid.y: 1 | grid.z: 1
Disposition: Passed
```

After the fix:
```
$ ./examples/sycl/pvc/pvc_gemm_persistent --iterations=0
Running GEMM with Normal schedule
grid.x: 20 | grid.y: 16 | grid.z: 1
Disposition: Passed

Running GEMM with Cooperative schedule
grid.x: 56 | grid.y: 1 | grid.z: 1
Disposition: Passed
```