### PR TITLE
Install dependency for nightly DPCPP

### DIFF
--- a/.github/actions/install-dpcpp/action.yml
+++ b/.github/actions/install-dpcpp/action.yml
@@ -19,6 +19,7 @@ runs:
       if: inputs.DPCPP_RELEASE == 'NIGHTLY'
       shell: bash
       run: |
+        sudo apt install -y libhwloc15
         export DPCPP_PATH=${{ inputs.DPCPP_PATH }}
         mkdir -p $DPCPP_PATH
         pushd $DPCPP_PATH
@@ -30,7 +31,6 @@ runs:
           latest=$(curl -sS https://api.github.com/repos/intel/llvm/releases | jq -r '[.[].tag_name|select(match("nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}"))][0]')
           URL=https://github.com/intel/llvm/releases/download/${latest}/sycl_linux.tar.gz;
         fi
-        sudo apt install -y libhwloc15
         echo "Downloading DPCPP from ${URL}"
         sudo wget -q $URL
         sudo tar -xf sycl_linux.tar.gz

--- a/.github/actions/install-dpcpp/action.yml
+++ b/.github/actions/install-dpcpp/action.yml
@@ -19,7 +19,7 @@ runs:
       if: inputs.DPCPP_RELEASE == 'NIGHTLY'
       shell: bash
       run: |
-        sudo apt install -y libhwloc15
+        dpkg -l | grep libhwloc15 > /dev/null || sudo apt install -y libhwloc15
         export DPCPP_PATH=${{ inputs.DPCPP_PATH }}
         mkdir -p $DPCPP_PATH
         pushd $DPCPP_PATH

--- a/.github/actions/install-dpcpp/action.yml
+++ b/.github/actions/install-dpcpp/action.yml
@@ -30,6 +30,7 @@ runs:
           latest=$(curl -sS https://api.github.com/repos/intel/llvm/releases | jq -r '[.[].tag_name|select(match("nightly-[0-9]{4}-[0-9]{2}-[0-9]{2}"))][0]')
           URL=https://github.com/intel/llvm/releases/download/${latest}/sycl_linux.tar.gz;
         fi
+        sudo apt install -y libhwloc15
         echo "Downloading DPCPP from ${URL}"
         sudo wget -q $URL
         sudo tar -xf sycl_linux.tar.gz

--- a/.github/workflows/nvidia_test.yml
+++ b/.github/workflows/nvidia_test.yml
@@ -33,7 +33,6 @@ jobs:
         shell: bash
         run: |
           nvidia-smi
-          sudo apt install -y libhwloc15
           mkdir ~/dpcpp
           pushd ~/dpcpp
           echo "Will use DPCPP ${{ inputs.DPCPP_VERSION }}."

--- a/.github/workflows/nvidia_test.yml
+++ b/.github/workflows/nvidia_test.yml
@@ -33,6 +33,7 @@ jobs:
         shell: bash
         run: |
           nvidia-smi
+          sudo apt install -y libhwloc15
           mkdir ~/dpcpp
           pushd ~/dpcpp
           echo "Will use DPCPP ${{ inputs.DPCPP_VERSION }}."


### PR DESCRIPTION
This PR fixes an issue in recent DPCPP nightly versions that require the libhwloc15 package.