### PR TITLE
Initial enablement of GemmUniversal3x instance emitting for PVC

### DIFF
--- a/python/cutlass_library/gemm_operation.py
+++ b/python/cutlass_library/gemm_operation.py
@@ -84,6 +84,7 @@ class GemmOperation:
     self.B = B
     self.C = C
     self.D = D
+    self.is_xe = self.arch == 11
 
     if is_block_scaled(gemm_kind):
       self.ScaleFactorA = ScaleFactorA
@@ -324,10 +325,20 @@ class GemmOperation:
           t = TileSchedulerSuffixes[self.tile_scheduler],
           k = self.kernel_schedule_name_3x(),
           e = self.epilogue_schedule_name_3x())
-    else:
+    elif not self.is_xe:
       threadblock = self.tile_description.procedural_name()
       return "cutlass{p}_{op}_{ex}_{tb}_{l}_align{a}".format(
           p = self.prefix,
+          op = opcode_class_name,
+          ex = self.extended_name(),
+          tb = threadblock,
+          l = self.layout_name(),
+          a = str(max(self.A.alignment, self.B.alignment)))
+    else:
+      threadblock = self.tile_description.procedural_name()
+      return "cutlass{p}_xe{ar}_{op}_{ex}_{tb}_{l}_align{a}".format(
+          p = self.prefix,
+          ar = self.arch,
           op = opcode_class_name,
           ex = self.extended_name(),
           tb = threadblock,
@@ -1059,6 +1070,10 @@ using {operation_name_str}_LayoutNarrowReordered = decltype(cute::tile_to_shape(
       'tile_scheduler': str(TileSchedulerTag[operation.tile_scheduler]),
       'mixed_dtype_prepare_code': mixed_dtype_prepare_code
     }
+
+    # Overriding values for Intel PVC
+    if operation.is_xe:  
+      values['arch'] = "cutlass::arch::IntelPVC"
 
     return SubstituteTemplate(self.gemm_template, values)
 


### PR DESCRIPTION
This patch introduces the minimal changes required to emit PVC compatible GemmUniversal3xInstances. This affects two classes only : 
- GemmOperation
- EmitGemmUniversal3xInstance

This is a partial enablement as it expects an interfacing with third party libraries (like Pytorch) rather than using the full emitting pipeline exposed by cutlass_library. In order to do so other classes including the other Gemm kinds, the wrapper class EmitGemmConfigurationLibrary and the Manifest class to name a few, need to incorporate relevant changes as well, which will be left to upcoming PRs.