### PR TITLE
Reduce test boilerplate by reusing common templates

### DIFF
--- a/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32.cpp
+++ b/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32.cpp
@@ -47,15 +47,15 @@ namespace {
 template <typename LayoutA, typename LayoutB>
 struct XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32 {
   using Config =
-    cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-      cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
+    gemm::device::DefaultGemmConfigurationToCutlass3Types<
+      arch::OpClassTensorOp, arch::IntelPVC,
       cute::bfloat16_t, LayoutA,
       cute::bfloat16_t, LayoutB,
-      float, cutlass::layout::RowMajor,
+      float, layout::RowMajor,
       float>;
 
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<
-    cutlass::gemm::kernel::GemmUniversal<
+  using Gemm = gemm::device::GemmUniversalAdapter<
+    gemm::kernel::GemmUniversal<
       cute::Shape<int,int,int,int>,
       typename Config::CollectiveMainloop,
       typename Config::CollectiveEpilogue>>;
@@ -63,25 +63,25 @@ struct XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32 {
 
 TEST(XE_Device_Gemm_bf16t_bf16t_f32t_tensor_op_f32, 256x256x32) {
   using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32<
-    cutlass::layout::RowMajor, cutlass::layout::RowMajor>::Gemm;
+    layout::RowMajor, layout::RowMajor>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
 TEST(XE_Device_Gemm_bf16n_bf16t_f32t_tensor_op_f32, 256x256x32) {
   using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32<
-    cutlass::layout::ColumnMajor, cutlass::layout::RowMajor>::Gemm;
+    layout::ColumnMajor, layout::RowMajor>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
 TEST(XE_Device_Gemm_bf16t_bf16n_f32t_tensor_op_f32, 256x256x32) {
   using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32<
-    cutlass::layout::RowMajor, cutlass::layout::ColumnMajor>::Gemm;
+    layout::RowMajor, layout::ColumnMajor>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
 TEST(XE_Device_Gemm_bf16n_bf16n_f32t_tensor_op_f32, 256x256x32) {
   using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32<
-    cutlass::layout::ColumnMajor, cutlass::layout::ColumnMajor>::Gemm;
+    layout::ColumnMajor, layout::ColumnMajor>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 

--- a/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32.cpp
+++ b/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32.cpp
@@ -42,75 +42,46 @@
 
 #include "gemm_testbed_3x.hpp"
 
+namespace {
+template <typename LayoutA, typename LayoutB>
+struct XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32 {
+  using Config =
+    cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
+      cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
+      cute::bfloat16_t, LayoutA,
+      cute::bfloat16_t, LayoutB,
+      float, cutlass::layout::RowMajor,
+      float>;
+
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<
+    cutlass::gemm::kernel::GemmUniversal<
+      cute::Shape<int,int,int,int>,
+      typename Config::CollectiveMainloop,
+      typename Config::CollectiveEpilogue>>;
+};
+}
+
 
 TEST(XE_Device_Gemm_bf16t_bf16t_f32t_tensor_op_f32, 256x256x32) {
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    cute::bfloat16_t, cutlass::layout::RowMajor,
-    cute::bfloat16_t, cutlass::layout::RowMajor,
-    float, cutlass::layout::RowMajor,
-    float>;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32<
+    cutlass::layout::RowMajor, cutlass::layout::RowMajor>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
 TEST(XE_Device_Gemm_bf16n_bf16t_f32t_tensor_op_f32, 256x256x32) {
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    cute::bfloat16_t, cutlass::layout::ColumnMajor,
-    cute::bfloat16_t, cutlass::layout::RowMajor,
-    float, cutlass::layout::RowMajor,
-    float>;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32<
+    cutlass::layout::ColumnMajor, cutlass::layout::RowMajor>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
 TEST(XE_Device_Gemm_bf16t_bf16n_f32t_tensor_op_f32, 256x256x32) {
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    cute::bfloat16_t, cutlass::layout::RowMajor,
-    cute::bfloat16_t, cutlass::layout::ColumnMajor,
-    float, cutlass::layout::RowMajor,
-    float>;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32<
+    cutlass::layout::RowMajor, cutlass::layout::ColumnMajor>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
 TEST(XE_Device_Gemm_bf16n_bf16n_f32t_tensor_op_f32, 256x256x32) {
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    cute::bfloat16_t, cutlass::layout::ColumnMajor,
-    cute::bfloat16_t, cutlass::layout::ColumnMajor,
-    float, cutlass::layout::RowMajor,
-    float>;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32<
+    cutlass::layout::ColumnMajor, cutlass::layout::ColumnMajor>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }

--- a/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32.cpp
+++ b/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32.cpp
@@ -42,6 +42,7 @@
 
 #include "gemm_testbed_3x.hpp"
 
+namespace cutlass {
 namespace {
 template <typename LayoutA, typename LayoutB>
 struct XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32 {
@@ -59,8 +60,6 @@ struct XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32 {
       typename Config::CollectiveMainloop,
       typename Config::CollectiveEpilogue>>;
 };
-}
-
 
 TEST(XE_Device_Gemm_bf16t_bf16t_f32t_tensor_op_f32, 256x256x32) {
   using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32<
@@ -85,3 +84,6 @@ TEST(XE_Device_Gemm_bf16n_bf16n_f32t_tensor_op_f32, 256x256x32) {
     cutlass::layout::ColumnMajor, cutlass::layout::ColumnMajor>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
+
+}
+} // namespace cutlass

--- a/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_cooperative.cpp
+++ b/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_cooperative.cpp
@@ -39,11 +39,13 @@
 
 #include "gemm_testbed_3x.hpp"
 
-TEST(XE_Device_Gemm_bf16t_bf16t_f32t_tensor_op_f32_cooperative, 256x256x32) {
+namespace {
+
+template <typename LayoutA, typename LayoutB>
+struct XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_cooperative {
   using ElementA = cute::bfloat16_t;
   using ElementB = cute::bfloat16_t;
-  using LayoutA = cutlass::layout::RowMajor;
-  using LayoutB = cutlass::layout::RowMajor;
+  using DispatchPolicy = cutlass::gemm::MainloopIntelPVC<3, cutlass::gemm::KernelPVCCooperative>;
 
   using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
     cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
@@ -52,133 +54,47 @@ TEST(XE_Device_Gemm_bf16t_bf16t_f32t_tensor_op_f32_cooperative, 256x256x32) {
     float, cutlass::layout::RowMajor,
     float>;
 
-  using DispatchPolicy = cutlass::gemm::MainloopIntelPVC<3, cutlass::gemm::KernelPVCCooperative>;
-
   using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
-    DispatchPolicy, Config::TileShape,
-    ElementA, cutlass::detail::TagToStrideA_t<LayoutA>,
-    ElementB, cutlass::detail::TagToStrideB_t<LayoutB>,
-    Config::TiledMma,
-    Config::GmemTiledCopyA, void, void, cute::identity,  // A
-    Config::GmemTiledCopyB, void, void, cute::identity   // B
-  >;
+      DispatchPolicy, typename Config::TileShape,
+      ElementA, cutlass::detail::TagToStrideA_t<LayoutA>,
+      ElementB, cutlass::detail::TagToStrideB_t<LayoutB>,
+      typename Config::TiledMma,
+      typename Config::GmemTiledCopyA, void, void, cute::identity,  // A
+      typename Config::GmemTiledCopyB, void, void, cute::identity>; // B
 
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      CollectiveMainloop,
-      Config::CollectiveEpilogue,
-      cutlass::gemm::StreamKScheduler
-  >;
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<
+    cutlass::gemm::kernel::GemmUniversal<
+     cute::Shape<int,int,int,int>,
+     CollectiveMainloop,
+     typename Config::CollectiveEpilogue,
+     cutlass::gemm::StreamKScheduler>>;
+};
+}
 
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+TEST(XE_Device_Gemm_bf16t_bf16t_f32t_tensor_op_f32_cooperative, 256x256x32) {
+  using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_cooperative<
+    cutlass::layout::RowMajor, cutlass::layout::RowMajor>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 TEST(XE_Device_Gemm_bf16n_bf16t_f32t_tensor_op_f32_cooperative, 256x256x32) {
-  using ElementA = cute::bfloat16_t;
-  using ElementB = cute::bfloat16_t;
-  using LayoutA = cutlass::layout::ColumnMajor;
-  using LayoutB = cutlass::layout::RowMajor;
-
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    ElementA, LayoutA,
-    ElementB, LayoutB,
-    float, cutlass::layout::RowMajor,
-    float>;
-
-  using DispatchPolicy = cutlass::gemm::MainloopIntelPVC<3, cutlass::gemm::KernelPVCCooperative>;
-
-  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
-    DispatchPolicy, Config::TileShape,
-    ElementA, cutlass::detail::TagToStrideA_t<LayoutA>,
-    ElementB, cutlass::detail::TagToStrideB_t<LayoutB>,
-    Config::TiledMma,
-    Config::GmemTiledCopyA, void, void, cute::identity,  // A
-    Config::GmemTiledCopyB, void, void, cute::identity   // B
-  >;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      CollectiveMainloop,
-      Config::CollectiveEpilogue,
-      cutlass::gemm::StreamKScheduler
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_cooperative<
+    cutlass::layout::ColumnMajor, cutlass::layout::RowMajor>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 TEST(XE_Device_Gemm_bf16t_bf16n_f32t_tensor_op_f32_cooperative, 256x256x32) {
-  using ElementA = cute::bfloat16_t;
-  using ElementB = cute::bfloat16_t;
-  using LayoutA = cutlass::layout::RowMajor;
-  using LayoutB = cutlass::layout::ColumnMajor;
-
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    ElementA, LayoutA,
-    ElementB, LayoutB,
-    float, cutlass::layout::RowMajor,
-    float>;
-
-  using DispatchPolicy = cutlass::gemm::MainloopIntelPVC<3, cutlass::gemm::KernelPVCCooperative>;
-
-  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
-    DispatchPolicy, Config::TileShape,
-    ElementA, cutlass::detail::TagToStrideA_t<LayoutA>,
-    ElementB, cutlass::detail::TagToStrideB_t<LayoutB>,
-    Config::TiledMma,
-    Config::GmemTiledCopyA, void, void, cute::identity,  // A
-    Config::GmemTiledCopyB, void, void, cute::identity   // B
-  >;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      CollectiveMainloop,
-      Config::CollectiveEpilogue,
-      cutlass::gemm::StreamKScheduler
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_cooperative<
+    cutlass::layout::RowMajor, cutlass::layout::ColumnMajor>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 TEST(XE_Device_Gemm_bf16n_bf16n_f32t_tensor_op_f32_cooperative, 256x256x32) {
-  using ElementA = cute::bfloat16_t;
-  using ElementB = cute::bfloat16_t;
-  using LayoutA = cutlass::layout::ColumnMajor;
-  using LayoutB = cutlass::layout::ColumnMajor;
-
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    ElementA, LayoutA,
-    ElementB, LayoutB,
-    float, cutlass::layout::RowMajor,
-    float>;
-
-  using DispatchPolicy = cutlass::gemm::MainloopIntelPVC<3, cutlass::gemm::KernelPVCCooperative>;
-
-  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
-    DispatchPolicy, Config::TileShape,
-    ElementA, cutlass::detail::TagToStrideA_t<LayoutA>,
-    ElementB, cutlass::detail::TagToStrideB_t<LayoutB>,
-    Config::TiledMma,
-    Config::GmemTiledCopyA, void, void, cute::identity,  // A
-    Config::GmemTiledCopyB, void, void, cute::identity   // B
-  >;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      CollectiveMainloop,
-      Config::CollectiveEpilogue,
-      cutlass::gemm::StreamKScheduler
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_cooperative<
+    cutlass::layout::ColumnMajor, cutlass::layout::ColumnMajor>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }

--- a/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_cooperative.cpp
+++ b/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_cooperative.cpp
@@ -39,6 +39,7 @@
 
 #include "gemm_testbed_3x.hpp"
 
+namespace cutlass {
 namespace {
 
 template <typename LayoutA, typename LayoutB>
@@ -69,7 +70,6 @@ struct XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_cooperative {
      typename Config::CollectiveEpilogue,
      cutlass::gemm::StreamKScheduler>>;
 };
-}
 
 TEST(XE_Device_Gemm_bf16t_bf16t_f32t_tensor_op_f32_cooperative, 256x256x32) {
   using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_cooperative<
@@ -98,3 +98,5 @@ TEST(XE_Device_Gemm_bf16n_bf16n_f32t_tensor_op_f32_cooperative, 256x256x32) {
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
+}
+} // namespace cutlass

--- a/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_cooperative.cpp
+++ b/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_cooperative.cpp
@@ -46,55 +46,55 @@ template <typename LayoutA, typename LayoutB>
 struct XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_cooperative {
   using ElementA = cute::bfloat16_t;
   using ElementB = cute::bfloat16_t;
-  using DispatchPolicy = cutlass::gemm::MainloopIntelPVC<3, cutlass::gemm::KernelPVCCooperative>;
+  using DispatchPolicy = gemm::MainloopIntelPVC<3, gemm::KernelPVCCooperative>;
 
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
+  using Config = gemm::device::DefaultGemmConfigurationToCutlass3Types<
+    arch::OpClassTensorOp, arch::IntelPVC,
     ElementA, LayoutA,
     ElementB, LayoutB,
-    float, cutlass::layout::RowMajor,
+    float, layout::RowMajor,
     float>;
 
-  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
+  using CollectiveMainloop = gemm::collective::CollectiveMma<
       DispatchPolicy, typename Config::TileShape,
-      ElementA, cutlass::detail::TagToStrideA_t<LayoutA>,
-      ElementB, cutlass::detail::TagToStrideB_t<LayoutB>,
+      ElementA, detail::TagToStrideA_t<LayoutA>,
+      ElementB, detail::TagToStrideB_t<LayoutB>,
       typename Config::TiledMma,
       typename Config::GmemTiledCopyA, void, void, cute::identity,  // A
       typename Config::GmemTiledCopyB, void, void, cute::identity>; // B
 
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<
-    cutlass::gemm::kernel::GemmUniversal<
+  using Gemm = gemm::device::GemmUniversalAdapter<
+    gemm::kernel::GemmUniversal<
      cute::Shape<int,int,int,int>,
      CollectiveMainloop,
      typename Config::CollectiveEpilogue,
-     cutlass::gemm::StreamKScheduler>>;
+     gemm::StreamKScheduler>>;
 };
 
 TEST(XE_Device_Gemm_bf16t_bf16t_f32t_tensor_op_f32_cooperative, 256x256x32) {
   using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_cooperative<
-    cutlass::layout::RowMajor, cutlass::layout::RowMajor>::Gemm;
+    layout::RowMajor, layout::RowMajor>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 TEST(XE_Device_Gemm_bf16n_bf16t_f32t_tensor_op_f32_cooperative, 256x256x32) {
   using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_cooperative<
-    cutlass::layout::ColumnMajor, cutlass::layout::RowMajor>::Gemm;
+    layout::ColumnMajor, layout::RowMajor>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 TEST(XE_Device_Gemm_bf16t_bf16n_f32t_tensor_op_f32_cooperative, 256x256x32) {
   using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_cooperative<
-    cutlass::layout::RowMajor, cutlass::layout::ColumnMajor>::Gemm;
+    layout::RowMajor, layout::ColumnMajor>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 TEST(XE_Device_Gemm_bf16n_bf16n_f32t_tensor_op_f32_cooperative, 256x256x32) {
   using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_cooperative<
-    cutlass::layout::ColumnMajor, cutlass::layout::ColumnMajor>::Gemm;
+    layout::ColumnMajor, layout::ColumnMajor>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }

--- a/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_evt.cpp
+++ b/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_evt.cpp
@@ -77,8 +77,6 @@ using CollectiveMainloop = typename cutlass::gemm::collective::CollectiveBuilder
 
 template <typename CollectiveEpilogue>
 struct XE_Device_Gemm_bf16_bf16_f32_tensor_op_gmma_f32_epilogue{
-
-
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<
     cutlass::gemm::kernel::GemmUniversal<
       Shape<int, int, int, int>,

--- a/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_evt.cpp
+++ b/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_evt.cpp
@@ -45,6 +45,7 @@
 
 #include "gemm_testbed_3x.hpp"
 
+namespace cutlass {
 namespace {
 using namespace cute;
 using LayoutA = cutlass::layout::RowMajor;
@@ -84,7 +85,6 @@ struct XE_Device_Gemm_bf16_bf16_f32_tensor_op_gmma_f32_epilogue{
       CollectiveEpilogue
     >>;
 };
-}
 
 // D = activation(alpha * acc + beta * C)
 TEST(XE_Device_Gemm_bf16t_bf16t_f32t_tensor_op_gmma_f32_epilogue, 256x256x32_LinCombEltAct) {
@@ -167,3 +167,5 @@ TEST(XE_Device_Gemm_bf16t_bf16t_f32_tensor_op_gmma_f32_epilogue, 256x256x32_LinC
   bool passed = test::gemm::device::TestXe<Gemm>(1.0, 0.0);
   EXPECT_TRUE(passed);
 }
+}
+} // namespace cutlass

--- a/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_group_gemm.cpp
+++ b/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_group_gemm.cpp
@@ -41,6 +41,7 @@
 #include "default_gemm_group_configuration.hpp"
 #include "gemm_testbed_3x_ptr_array.hpp"
 
+namespace cutlass {
 namespace {
 template <typename LayoutA, typename LayoutB>
 struct XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_group_gemm {
@@ -63,7 +64,6 @@ struct XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_group_gemm {
       cutlass::gemm::GroupScheduler
     >>;
 };
-}
 
 TEST(XE_Device_Gemm_bf16t_bf16t_f32t_tensor_op_f32_group_gemm, 256x256x32) {
   using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_group_gemm<
@@ -96,3 +96,5 @@ TEST(XE_Device_Gemm_bf16n_bf16n_f32t_tensor_op_f32_group_gemm, 256x256x32) {
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 1.0));
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 0.0));
 }
+}
+} // namespace cutlass

--- a/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_group_gemm.cpp
+++ b/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_group_gemm.cpp
@@ -49,25 +49,25 @@ struct XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_group_gemm {
   using ElementB = cute::bfloat16_t;
   using ElementC = float;
   using ElementAccumulator = float;
-  using LayoutC = cutlass::layout::RowMajor;
-  using ProblemShape = cutlass::gemm::GroupProblemShape<cute::Shape<int,int,int>>; // <M,N,K> per group
+  using LayoutC = layout::RowMajor;
+  using ProblemShape = gemm::GroupProblemShape<cute::Shape<int,int,int>>; // <M,N,K> per group
 
-  using Config = cutlass::gemm::device::DefaultGemmGroupConfiguration<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
+  using Config = gemm::device::DefaultGemmGroupConfiguration<
+    arch::OpClassTensorOp, arch::IntelPVC,
     ElementA, LayoutA, ElementB, LayoutB, ElementC, LayoutC, ElementAccumulator>;
 
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<
-    cutlass::gemm::kernel::GemmUniversal<
+  using Gemm = gemm::device::GemmUniversalAdapter<
+    gemm::kernel::GemmUniversal<
       ProblemShape,
       typename Config::CollectiveMainloop,
       typename Config::CollectiveEpilogue,
-      cutlass::gemm::GroupScheduler
+      gemm::GroupScheduler
     >>;
 };
 
 TEST(XE_Device_Gemm_bf16t_bf16t_f32t_tensor_op_f32_group_gemm, 256x256x32) {
   using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_group_gemm<
-    cutlass::layout::RowMajor, cutlass::layout::RowMajor>::Gemm;
+    layout::RowMajor, layout::RowMajor>::Gemm;
 
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 1.0));
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 0.0));
@@ -75,7 +75,7 @@ TEST(XE_Device_Gemm_bf16t_bf16t_f32t_tensor_op_f32_group_gemm, 256x256x32) {
 
 TEST(XE_Device_Gemm_bf16n_bf16t_f32t_tensor_op_f32_group_gemm, 256x256x32) {
   using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_group_gemm<
-    cutlass::layout::ColumnMajor, cutlass::layout::RowMajor>::Gemm;
+    layout::ColumnMajor, layout::RowMajor>::Gemm;
 
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 1.0));
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 0.0));
@@ -83,7 +83,7 @@ TEST(XE_Device_Gemm_bf16n_bf16t_f32t_tensor_op_f32_group_gemm, 256x256x32) {
 
 TEST(XE_Device_Gemm_bf16t_bf16n_f32t_tensor_op_f32_group_gemm, 256x256x32) {
   using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_group_gemm<
-    cutlass::layout::RowMajor, cutlass::layout::ColumnMajor>::Gemm;
+    layout::RowMajor, layout::ColumnMajor>::Gemm;
 
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 1.0));
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 0.0));
@@ -91,7 +91,7 @@ TEST(XE_Device_Gemm_bf16t_bf16n_f32t_tensor_op_f32_group_gemm, 256x256x32) {
 
 TEST(XE_Device_Gemm_bf16n_bf16n_f32t_tensor_op_f32_group_gemm, 256x256x32) {
   using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_group_gemm<
-    cutlass::layout::ColumnMajor, cutlass::layout::ColumnMajor>::Gemm;
+    layout::ColumnMajor, layout::ColumnMajor>::Gemm;
 
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 1.0));
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 0.0));

--- a/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_group_gemm.cpp
+++ b/test/unit/gemm/device/xe_gemm_bf16_bf16_fp32_tensor_op_fp32_group_gemm.cpp
@@ -41,107 +41,57 @@
 #include "default_gemm_group_configuration.hpp"
 #include "gemm_testbed_3x_ptr_array.hpp"
 
-using ProblemShape = cutlass::gemm::GroupProblemShape<cute::Shape<int,int,int>>; // <M,N,K> per group
-
-TEST(XE_Device_Gemm_bf16t_bf16t_f32t_tensor_op_f32_group_gemm, 256x256x32) {
+namespace {
+template <typename LayoutA, typename LayoutB>
+struct XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_group_gemm {
   using ElementA = cute::bfloat16_t;
   using ElementB = cute::bfloat16_t;
   using ElementC = float;
   using ElementAccumulator = float;
-  using LayoutA = cutlass::layout::RowMajor;
-  using LayoutB = cutlass::layout::RowMajor;
   using LayoutC = cutlass::layout::RowMajor;
+  using ProblemShape = cutlass::gemm::GroupProblemShape<cute::Shape<int,int,int>>; // <M,N,K> per group
 
   using Config = cutlass::gemm::device::DefaultGemmGroupConfiguration<
     cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
     ElementA, LayoutA, ElementB, LayoutB, ElementC, LayoutC, ElementAccumulator>;
 
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<
+    cutlass::gemm::kernel::GemmUniversal<
       ProblemShape,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue,
+      typename Config::CollectiveMainloop,
+      typename Config::CollectiveEpilogue,
       cutlass::gemm::GroupScheduler
-  >;
+    >>;
+};
+}
 
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+TEST(XE_Device_Gemm_bf16t_bf16t_f32t_tensor_op_f32_group_gemm, 256x256x32) {
+  using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_group_gemm<
+    cutlass::layout::RowMajor, cutlass::layout::RowMajor>::Gemm;
 
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 1.0));
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 0.0));
 }
 
 TEST(XE_Device_Gemm_bf16n_bf16t_f32t_tensor_op_f32_group_gemm, 256x256x32) {
-  using ElementA = cute::bfloat16_t;
-  using ElementB = cute::bfloat16_t;
-  using ElementC = float;
-  using ElementAccumulator = float;
-  using LayoutA = cutlass::layout::ColumnMajor;
-  using LayoutB = cutlass::layout::RowMajor;
-  using LayoutC = cutlass::layout::RowMajor;
-
-  using Config = cutlass::gemm::device::DefaultGemmGroupConfiguration<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    ElementA, LayoutA, ElementB, LayoutB, ElementC, LayoutC, ElementAccumulator>;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      ProblemShape,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue,
-      cutlass::gemm::GroupScheduler
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_group_gemm<
+    cutlass::layout::ColumnMajor, cutlass::layout::RowMajor>::Gemm;
 
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 1.0));
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 0.0));
 }
 
 TEST(XE_Device_Gemm_bf16t_bf16n_f32t_tensor_op_f32_group_gemm, 256x256x32) {
-  using ElementA = cute::bfloat16_t;
-  using ElementB = cute::bfloat16_t;
-  using ElementC = float;
-  using ElementAccumulator = float;
-  using LayoutA = cutlass::layout::RowMajor;
-  using LayoutB = cutlass::layout::ColumnMajor;
-  using LayoutC = cutlass::layout::RowMajor;
-
-  using Config = cutlass::gemm::device::DefaultGemmGroupConfiguration<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    ElementA, LayoutA, ElementB, LayoutB, ElementC, LayoutC, ElementAccumulator>;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      ProblemShape,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue,
-      cutlass::gemm::GroupScheduler
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_group_gemm<
+    cutlass::layout::RowMajor, cutlass::layout::ColumnMajor>::Gemm;
 
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 1.0));
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 0.0));
 }
 
 TEST(XE_Device_Gemm_bf16n_bf16n_f32t_tensor_op_f32_group_gemm, 256x256x32) {
-  using ElementA = cute::bfloat16_t;
-  using ElementB = cute::bfloat16_t;
-  using ElementC = float;
-  using ElementAccumulator = float;
-  using LayoutA = cutlass::layout::ColumnMajor;
-  using LayoutB = cutlass::layout::ColumnMajor;
-  using LayoutC = cutlass::layout::RowMajor;
-
-  using Config = cutlass::gemm::device::DefaultGemmGroupConfiguration<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    ElementA, LayoutA, ElementB, LayoutB, ElementC, LayoutC, ElementAccumulator>;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      ProblemShape,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue,
-      cutlass::gemm::GroupScheduler
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_bf16_bf16_f32_tensor_op_f32_group_gemm<
+    cutlass::layout::ColumnMajor, cutlass::layout::ColumnMajor>::Gemm;
 
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 1.0));
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 0.0));

--- a/test/unit/gemm/device/xe_gemm_fp16_fp16_fp32_tensor_op_fp32.cpp
+++ b/test/unit/gemm/device/xe_gemm_fp16_fp16_fp32_tensor_op_fp32.cpp
@@ -42,6 +42,7 @@
 
 #include "gemm_testbed_3x.hpp"
 
+namespace cutlass {
 namespace {
 template <typename LayoutA, typename LayoutB>
 struct XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32 {
@@ -57,7 +58,6 @@ struct XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32 {
     typename Config::CollectiveMainloop,
     typename Config::CollectiveEpilogue>>;
 };
-}
 
 
 TEST(XE_Device_Gemm_fp16t_fp16t_f32t_tensor_op_f32, 256x256x32) {
@@ -83,3 +83,5 @@ TEST(XE_Device_Gemm_fp16n_fp16n_f32t_tensor_op_f32, 256x256x32) {
     cutlass::layout::ColumnMajor, cutlass::layout::ColumnMajor>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
+}
+} // namespace cutlass

--- a/test/unit/gemm/device/xe_gemm_fp16_fp16_fp32_tensor_op_fp32.cpp
+++ b/test/unit/gemm/device/xe_gemm_fp16_fp16_fp32_tensor_op_fp32.cpp
@@ -48,7 +48,7 @@ struct XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32 {
   using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
     cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
     cute::half_t, LayoutA,
-    cute::half_t, LayoutA,
+    cute::half_t, LayoutB,
     float, cutlass::layout::RowMajor,
     float>;
 

--- a/test/unit/gemm/device/xe_gemm_fp16_fp16_fp32_tensor_op_fp32.cpp
+++ b/test/unit/gemm/device/xe_gemm_fp16_fp16_fp32_tensor_op_fp32.cpp
@@ -42,75 +42,44 @@
 
 #include "gemm_testbed_3x.hpp"
 
-
-TEST(XE_Device_Gemm_fp16t_fp16t_f32t_tensor_op_f32, 256x256x32) {
+namespace {
+template <typename LayoutA, typename LayoutB>
+struct XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32 {
   using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
     cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    cute::half_t, cutlass::layout::RowMajor,
-    cute::half_t, cutlass::layout::RowMajor,
+    cute::half_t, LayoutA,
+    cute::half_t, LayoutA,
     float, cutlass::layout::RowMajor,
     float>;
 
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue
-  >;
+  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<cutlass::gemm::kernel::GemmUniversal<
+    cute::Shape<int,int,int,int>,
+    typename Config::CollectiveMainloop,
+    typename Config::CollectiveEpilogue>>;
+};
+}
 
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+
+TEST(XE_Device_Gemm_fp16t_fp16t_f32t_tensor_op_f32, 256x256x32) {
+  using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32<
+    cutlass::layout::RowMajor, cutlass::layout::RowMajor>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
 TEST(XE_Device_Gemm_fp16n_fp16t_f32t_tensor_op_f32, 256x256x32) {
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    cute::half_t, cutlass::layout::ColumnMajor,
-    cute::half_t, cutlass::layout::RowMajor,
-    float, cutlass::layout::RowMajor,
-    float>;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32<
+    cutlass::layout::ColumnMajor, cutlass::layout::RowMajor>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
 TEST(XE_Device_Gemm_fp16t_fp16n_f32t_tensor_op_f32, 256x256x32) {
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    cute::half_t, cutlass::layout::RowMajor,
-    cute::half_t, cutlass::layout::ColumnMajor,
-    float, cutlass::layout::RowMajor,
-    float>;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32<
+    cutlass::layout::RowMajor, cutlass::layout::ColumnMajor>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
 TEST(XE_Device_Gemm_fp16n_fp16n_f32t_tensor_op_f32, 256x256x32) {
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    cute::half_t, cutlass::layout::ColumnMajor,
-    cute::half_t, cutlass::layout::ColumnMajor,
-    float, cutlass::layout::RowMajor,
-    float>;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32<
+    cutlass::layout::ColumnMajor, cutlass::layout::ColumnMajor>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }

--- a/test/unit/gemm/device/xe_gemm_fp16_fp16_fp32_tensor_op_fp32.cpp
+++ b/test/unit/gemm/device/xe_gemm_fp16_fp16_fp32_tensor_op_fp32.cpp
@@ -46,14 +46,14 @@ namespace cutlass {
 namespace {
 template <typename LayoutA, typename LayoutB>
 struct XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32 {
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
+  using Config = gemm::device::DefaultGemmConfigurationToCutlass3Types<
+    arch::OpClassTensorOp, arch::IntelPVC,
     cute::half_t, LayoutA,
     cute::half_t, LayoutB,
-    float, cutlass::layout::RowMajor,
+    float, layout::RowMajor,
     float>;
 
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<cutlass::gemm::kernel::GemmUniversal<
+  using Gemm = gemm::device::GemmUniversalAdapter<gemm::kernel::GemmUniversal<
     cute::Shape<int,int,int,int>,
     typename Config::CollectiveMainloop,
     typename Config::CollectiveEpilogue>>;
@@ -62,25 +62,25 @@ struct XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32 {
 
 TEST(XE_Device_Gemm_fp16t_fp16t_f32t_tensor_op_f32, 256x256x32) {
   using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32<
-    cutlass::layout::RowMajor, cutlass::layout::RowMajor>::Gemm;
+    layout::RowMajor, layout::RowMajor>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
 TEST(XE_Device_Gemm_fp16n_fp16t_f32t_tensor_op_f32, 256x256x32) {
   using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32<
-    cutlass::layout::ColumnMajor, cutlass::layout::RowMajor>::Gemm;
+    layout::ColumnMajor, layout::RowMajor>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
 TEST(XE_Device_Gemm_fp16t_fp16n_f32t_tensor_op_f32, 256x256x32) {
   using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32<
-    cutlass::layout::RowMajor, cutlass::layout::ColumnMajor>::Gemm;
+    layout::RowMajor, layout::ColumnMajor>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
 TEST(XE_Device_Gemm_fp16n_fp16n_f32t_tensor_op_f32, 256x256x32) {
   using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32<
-    cutlass::layout::ColumnMajor, cutlass::layout::ColumnMajor>::Gemm;
+    layout::ColumnMajor, layout::ColumnMajor>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 }

--- a/test/unit/gemm/device/xe_gemm_fp16_fp16_fp32_tensor_op_fp32_cooperative.cpp
+++ b/test/unit/gemm/device/xe_gemm_fp16_fp16_fp32_tensor_op_fp32_cooperative.cpp
@@ -39,11 +39,11 @@
 
 #include "gemm_testbed_3x.hpp"
 
-TEST(XE_Device_Gemm_fp16t_fp16t_f32t_tensor_op_f32_cooperative, 256x256x32) {
+namespace {
+template <typename LayoutA, typename LayoutB>
+struct XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_cooperative {
   using ElementA = cute::half_t;
   using ElementB = cute::half_t;
-  using LayoutA = cutlass::layout::RowMajor;
-  using LayoutB = cutlass::layout::RowMajor;
 
   using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
     cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
@@ -71,114 +71,37 @@ TEST(XE_Device_Gemm_fp16t_fp16t_f32t_tensor_op_f32_cooperative, 256x256x32) {
   >;
 
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+};
+}
+
+TEST(XE_Device_Gemm_fp16t_fp16t_f32t_tensor_op_f32_cooperative, 256x256x32) {
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::RowMajor;
+  using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 TEST(XE_Device_Gemm_fp16n_fp16t_f32t_tensor_op_f32_cooperative, 256x256x32) {
-  using ElementA = cute::half_t;
-  using ElementB = cute::half_t;
   using LayoutA = cutlass::layout::ColumnMajor;
   using LayoutB = cutlass::layout::RowMajor;
-
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    ElementA, LayoutA,
-    ElementB, LayoutB,
-    float, cutlass::layout::RowMajor,
-    float>;
-
-  using DispatchPolicy = cutlass::gemm::MainloopIntelPVC<3, cutlass::gemm::KernelPVCCooperative>;
-
-  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
-    DispatchPolicy, Config::TileShape,
-    ElementA, cutlass::detail::TagToStrideA_t<LayoutA>,
-    ElementB, cutlass::detail::TagToStrideB_t<LayoutB>,
-    Config::TiledMma,
-    Config::GmemTiledCopyA, void, void, cute::identity,  // A
-    Config::GmemTiledCopyB, void, void, cute::identity   // B
-  >;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      CollectiveMainloop,
-      Config::CollectiveEpilogue,
-      cutlass::gemm::StreamKScheduler
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 TEST(XE_Device_Gemm_fp16t_fp16n_f32t_tensor_op_f32_cooperative, 256x256x32) {
-  using ElementA = cute::half_t;
-  using ElementB = cute::half_t;
   using LayoutA = cutlass::layout::RowMajor;
   using LayoutB = cutlass::layout::ColumnMajor;
-
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    ElementA, LayoutA,
-    ElementB, LayoutB,
-    float, cutlass::layout::RowMajor,
-    float>;
-
-  using DispatchPolicy = cutlass::gemm::MainloopIntelPVC<3, cutlass::gemm::KernelPVCCooperative>;
-
-  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
-    DispatchPolicy, Config::TileShape,
-    ElementA, cutlass::detail::TagToStrideA_t<LayoutA>,
-    ElementB, cutlass::detail::TagToStrideB_t<LayoutB>,
-    Config::TiledMma,
-    Config::GmemTiledCopyA, void, void, cute::identity,  // A
-    Config::GmemTiledCopyB, void, void, cute::identity   // B
-  >;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      CollectiveMainloop,
-      Config::CollectiveEpilogue,
-      cutlass::gemm::StreamKScheduler
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 TEST(XE_Device_Gemm_fp16n_fp16n_f32t_tensor_op_f32_cooperative, 256x256x32) {
-  using ElementA = cute::half_t;
-  using ElementB = cute::half_t;
   using LayoutA = cutlass::layout::ColumnMajor;
   using LayoutB = cutlass::layout::ColumnMajor;
-
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    ElementA, LayoutA,
-    ElementB, LayoutB,
-    float, cutlass::layout::RowMajor,
-    float>;
-
-  using DispatchPolicy = cutlass::gemm::MainloopIntelPVC<3, cutlass::gemm::KernelPVCCooperative>;
-
-  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
-    DispatchPolicy, Config::TileShape,
-    ElementA, cutlass::detail::TagToStrideA_t<LayoutA>,
-    ElementB, cutlass::detail::TagToStrideB_t<LayoutB>,
-    Config::TiledMma,
-    Config::GmemTiledCopyA, void, void, cute::identity,  // A
-    Config::GmemTiledCopyB, void, void, cute::identity   // B
-  >;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      CollectiveMainloop,
-      Config::CollectiveEpilogue,
-      cutlass::gemm::StreamKScheduler
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }

--- a/test/unit/gemm/device/xe_gemm_fp16_fp16_fp32_tensor_op_fp32_cooperative.cpp
+++ b/test/unit/gemm/device/xe_gemm_fp16_fp16_fp32_tensor_op_fp32_cooperative.cpp
@@ -39,6 +39,7 @@
 
 #include "gemm_testbed_3x.hpp"
 
+namespace cutlass {
 namespace {
 template <typename LayoutA, typename LayoutB>
 struct XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_cooperative {
@@ -72,7 +73,6 @@ struct XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_cooperative {
 
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
 };
-}
 
 TEST(XE_Device_Gemm_fp16t_fp16t_f32t_tensor_op_f32_cooperative, 256x256x32) {
   using LayoutA = cutlass::layout::RowMajor;
@@ -105,3 +105,5 @@ TEST(XE_Device_Gemm_fp16n_fp16n_f32t_tensor_op_f32_cooperative, 256x256x32) {
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
+}
+} // namespace cutlass

--- a/test/unit/gemm/device/xe_gemm_fp16_fp16_fp32_tensor_op_fp32_cooperative.cpp
+++ b/test/unit/gemm/device/xe_gemm_fp16_fp16_fp32_tensor_op_fp32_cooperative.cpp
@@ -46,61 +46,61 @@ struct XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_cooperative {
   using ElementA = cute::half_t;
   using ElementB = cute::half_t;
 
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
+  using Config = gemm::device::DefaultGemmConfigurationToCutlass3Types<
+    arch::OpClassTensorOp, arch::IntelPVC,
     ElementA, LayoutA,
     ElementB, LayoutB,
-    float, cutlass::layout::RowMajor,
+    float, layout::RowMajor,
     float>;
 
-  using DispatchPolicy = cutlass::gemm::MainloopIntelPVC<3, cutlass::gemm::KernelPVCCooperative>;
+  using DispatchPolicy = gemm::MainloopIntelPVC<3, gemm::KernelPVCCooperative>;
 
-  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
+  using CollectiveMainloop = gemm::collective::CollectiveMma<
     DispatchPolicy, Config::TileShape,
-    ElementA, cutlass::detail::TagToStrideA_t<LayoutA>,
-    ElementB, cutlass::detail::TagToStrideB_t<LayoutB>,
+    ElementA, detail::TagToStrideA_t<LayoutA>,
+    ElementB, detail::TagToStrideB_t<LayoutB>,
     Config::TiledMma,
     Config::GmemTiledCopyA, void, void, cute::identity,  // A
     Config::GmemTiledCopyB, void, void, cute::identity   // B
   >;
 
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+  using GemmKernel = gemm::kernel::GemmUniversal<
       cute::Shape<int,int,int,int>,
       CollectiveMainloop,
       Config::CollectiveEpilogue,
-      cutlass::gemm::StreamKScheduler
+      gemm::StreamKScheduler
   >;
 
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = gemm::device::GemmUniversalAdapter<GemmKernel>;
 };
 
 TEST(XE_Device_Gemm_fp16t_fp16t_f32t_tensor_op_f32_cooperative, 256x256x32) {
-  using LayoutA = cutlass::layout::RowMajor;
-  using LayoutB = cutlass::layout::RowMajor;
+  using LayoutA = layout::RowMajor;
+  using LayoutB = layout::RowMajor;
   using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 TEST(XE_Device_Gemm_fp16n_fp16t_f32t_tensor_op_f32_cooperative, 256x256x32) {
-  using LayoutA = cutlass::layout::ColumnMajor;
-  using LayoutB = cutlass::layout::RowMajor;
+  using LayoutA = layout::ColumnMajor;
+  using LayoutB = layout::RowMajor;
   using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 TEST(XE_Device_Gemm_fp16t_fp16n_f32t_tensor_op_f32_cooperative, 256x256x32) {
-  using LayoutA = cutlass::layout::RowMajor;
-  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutA = layout::RowMajor;
+  using LayoutB = layout::ColumnMajor;
   using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 TEST(XE_Device_Gemm_fp16n_fp16n_f32t_tensor_op_f32_cooperative, 256x256x32) {
-  using LayoutA = cutlass::layout::ColumnMajor;
-  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutA = layout::ColumnMajor;
+  using LayoutB = layout::ColumnMajor;
   using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));

--- a/test/unit/gemm/device/xe_gemm_fp16_fp16_fp32_tensor_op_fp32_group_gemm.cpp
+++ b/test/unit/gemm/device/xe_gemm_fp16_fp16_fp32_tensor_op_fp32_group_gemm.cpp
@@ -45,54 +45,54 @@ namespace cutlass {
 namespace {
 template <typename LayoutA, typename LayoutB>
 struct XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_group_gemm {
-  using ProblemShape = cutlass::gemm::GroupProblemShape<cute::Shape<int,int,int>>; // <M,N,K> per group
+  using ProblemShape = gemm::GroupProblemShape<cute::Shape<int,int,int>>; // <M,N,K> per group
   using ElementA = cute::half_t;
   using ElementB = cute::half_t;
   using ElementC = float;
   using ElementAccumulator = float;
-  using LayoutC = cutlass::layout::RowMajor;
+  using LayoutC = layout::RowMajor;
 
-  using Config = cutlass::gemm::device::DefaultGemmGroupConfiguration<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
+  using Config = gemm::device::DefaultGemmGroupConfiguration<
+    arch::OpClassTensorOp, arch::IntelPVC,
     ElementA, LayoutA, ElementB, LayoutB, ElementC, LayoutC, ElementAccumulator>;
 
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+  using GemmKernel = gemm::kernel::GemmUniversal<
       ProblemShape,
       typename Config::CollectiveMainloop,
       typename Config::CollectiveEpilogue,
-      cutlass::gemm::GroupScheduler
+      gemm::GroupScheduler
   >;
 
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = gemm::device::GemmUniversalAdapter<GemmKernel>;
 };
 
 TEST(XE_Device_Gemm_fp16t_fp16t_f32t_tensor_op_f32_group_gemm, 256x256x32) {
-  using LayoutA = cutlass::layout::RowMajor;
-  using LayoutB = cutlass::layout::RowMajor;
+  using LayoutA = layout::RowMajor;
+  using LayoutB = layout::RowMajor;
   using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_group_gemm<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 1.0));
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 0.0));
 }
 
 TEST(XE_Device_Gemm_fp16n_fp16t_f32t_tensor_op_f32_group_gemm, 256x256x32) {
-  using LayoutA = cutlass::layout::ColumnMajor;
-  using LayoutB = cutlass::layout::RowMajor;
+  using LayoutA = layout::ColumnMajor;
+  using LayoutB = layout::RowMajor;
   using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_group_gemm<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 1.0));
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 0.0));
 }
 
 TEST(XE_Device_Gemm_fp16t_fp16n_f32t_tensor_op_f32_group_gemm, 256x256x32) {
-  using LayoutA = cutlass::layout::RowMajor;
-  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutA = layout::RowMajor;
+  using LayoutB = layout::ColumnMajor;
   using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_group_gemm<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 1.0));
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 0.0));
 }
 
 TEST(XE_Device_Gemm_fp16n_fp16n_f32t_tensor_op_f32_group_gemm, 256x256x32) {
-  using LayoutA = cutlass::layout::ColumnMajor;
-  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutA = layout::ColumnMajor;
+  using LayoutB = layout::ColumnMajor;
   using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_group_gemm<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 1.0));
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 0.0));

--- a/test/unit/gemm/device/xe_gemm_fp16_fp16_fp32_tensor_op_fp32_group_gemm.cpp
+++ b/test/unit/gemm/device/xe_gemm_fp16_fp16_fp32_tensor_op_fp32_group_gemm.cpp
@@ -41,6 +41,7 @@
 #include "default_gemm_group_configuration.hpp"
 #include "gemm_testbed_3x_ptr_array.hpp"
 
+namespace cutlass {
 namespace {
 template <typename LayoutA, typename LayoutB>
 struct XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_group_gemm {
@@ -64,7 +65,6 @@ struct XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_group_gemm {
 
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
 };
-}
 
 TEST(XE_Device_Gemm_fp16t_fp16t_f32t_tensor_op_f32_group_gemm, 256x256x32) {
   using LayoutA = cutlass::layout::RowMajor;
@@ -97,3 +97,5 @@ TEST(XE_Device_Gemm_fp16n_fp16n_f32t_tensor_op_f32_group_gemm, 256x256x32) {
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 1.0));
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 0.0));
 }
+}
+} // namespace cutlass

--- a/test/unit/gemm/device/xe_gemm_fp16_fp16_fp32_tensor_op_fp32_group_gemm.cpp
+++ b/test/unit/gemm/device/xe_gemm_fp16_fp16_fp32_tensor_op_fp32_group_gemm.cpp
@@ -41,15 +41,14 @@
 #include "default_gemm_group_configuration.hpp"
 #include "gemm_testbed_3x_ptr_array.hpp"
 
-using ProblemShape = cutlass::gemm::GroupProblemShape<cute::Shape<int,int,int>>; // <M,N,K> per group
-
-TEST(XE_Device_Gemm_fp16t_fp16t_f32t_tensor_op_f32_group_gemm, 256x256x32) {
+namespace {
+template <typename LayoutA, typename LayoutB>
+struct XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_group_gemm {
+  using ProblemShape = cutlass::gemm::GroupProblemShape<cute::Shape<int,int,int>>; // <M,N,K> per group
   using ElementA = cute::half_t;
   using ElementB = cute::half_t;
   using ElementC = float;
   using ElementAccumulator = float;
-  using LayoutA = cutlass::layout::RowMajor;
-  using LayoutB = cutlass::layout::RowMajor;
   using LayoutC = cutlass::layout::RowMajor;
 
   using Config = cutlass::gemm::device::DefaultGemmGroupConfiguration<
@@ -58,91 +57,43 @@ TEST(XE_Device_Gemm_fp16t_fp16t_f32t_tensor_op_f32_group_gemm, 256x256x32) {
 
   using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
       ProblemShape,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue,
+      typename Config::CollectiveMainloop,
+      typename Config::CollectiveEpilogue,
       cutlass::gemm::GroupScheduler
   >;
 
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+};
+}
 
+TEST(XE_Device_Gemm_fp16t_fp16t_f32t_tensor_op_f32_group_gemm, 256x256x32) {
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::RowMajor;
+  using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_group_gemm<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 1.0));
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 0.0));
 }
 
 TEST(XE_Device_Gemm_fp16n_fp16t_f32t_tensor_op_f32_group_gemm, 256x256x32) {
-  using ElementA = cute::half_t;
-  using ElementB = cute::half_t;
-  using ElementC = float;
-  using ElementAccumulator = float;
   using LayoutA = cutlass::layout::ColumnMajor;
   using LayoutB = cutlass::layout::RowMajor;
-  using LayoutC = cutlass::layout::RowMajor;
-
-  using Config = cutlass::gemm::device::DefaultGemmGroupConfiguration<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    ElementA, LayoutA, ElementB, LayoutB, ElementC, LayoutC, ElementAccumulator>;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      ProblemShape,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue,
-      cutlass::gemm::GroupScheduler
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
-
+  using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_group_gemm<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 1.0));
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 0.0));
 }
 
 TEST(XE_Device_Gemm_fp16t_fp16n_f32t_tensor_op_f32_group_gemm, 256x256x32) {
-  using ElementA = cute::half_t;
-  using ElementB = cute::half_t;
-  using ElementC = float;
-  using ElementAccumulator = float;
   using LayoutA = cutlass::layout::RowMajor;
   using LayoutB = cutlass::layout::ColumnMajor;
-  using LayoutC = cutlass::layout::RowMajor;
-
-  using Config = cutlass::gemm::device::DefaultGemmGroupConfiguration<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    ElementA, LayoutA, ElementB, LayoutB, ElementC, LayoutC, ElementAccumulator>;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      ProblemShape,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue,
-      cutlass::gemm::GroupScheduler
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
-
+  using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_group_gemm<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 1.0));
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 0.0));
 }
 
 TEST(XE_Device_Gemm_fp16n_fp16n_f32t_tensor_op_f32_group_gemm, 256x256x32) {
-  using ElementA = cute::half_t;
-  using ElementB = cute::half_t;
-  using ElementC = float;
-  using ElementAccumulator = float;
   using LayoutA = cutlass::layout::ColumnMajor;
   using LayoutB = cutlass::layout::ColumnMajor;
-  using LayoutC = cutlass::layout::RowMajor;
-
-  using Config = cutlass::gemm::device::DefaultGemmGroupConfiguration<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    ElementA, LayoutA, ElementB, LayoutB, ElementC, LayoutC, ElementAccumulator>;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      ProblemShape,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue,
-      cutlass::gemm::GroupScheduler
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
-
+  using Gemm = XE_Device_Gemm_fp16_fp16_f32_tensor_op_f32_group_gemm<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 1.0));
   EXPECT_TRUE(test::gemm::device::TestAll<Gemm>(1.0, 0.0));
 }

--- a/test/unit/gemm/device/xe_gemm_s8_s8_s32_tensor_op_s32.cpp
+++ b/test/unit/gemm/device/xe_gemm_s8_s8_s32_tensor_op_s32.cpp
@@ -42,6 +42,7 @@
 
 #include "gemm_testbed_3x.hpp"
 
+namespace cutlass {
 namespace {
 template <typename LayoutA, typename LayoutB>
 struct XE_Device_Gemm_s8_s8_s32_tensor_op_s32 {
@@ -59,7 +60,6 @@ struct XE_Device_Gemm_s8_s8_s32_tensor_op_s32 {
 
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
 };
-}
 
 TEST(XE_Device_Gemm_s8t_s8t_s32t_tensor_op_s32, 256x256x32) {
   using LayoutA = cutlass::layout::RowMajor;
@@ -90,3 +90,5 @@ TEST(XE_Device_Gemm_s8n_s8n_s32t_tensor_op_s32, 64x128x32) {
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 */
+}
+} // namespace cutlass

--- a/test/unit/gemm/device/xe_gemm_s8_s8_s32_tensor_op_s32.cpp
+++ b/test/unit/gemm/device/xe_gemm_s8_s8_s32_tensor_op_s32.cpp
@@ -46,46 +46,46 @@ namespace cutlass {
 namespace {
 template <typename LayoutA, typename LayoutB>
 struct XE_Device_Gemm_s8_s8_s32_tensor_op_s32 {
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
+  using Config = gemm::device::DefaultGemmConfigurationToCutlass3Types<
+    arch::OpClassTensorOp, arch::IntelPVC,
     int8_t, LayoutA,
     int8_t, LayoutB,
-    int32_t, cutlass::layout::RowMajor,
+    int32_t, layout::RowMajor,
     int32_t>;
 
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+  using GemmKernel = gemm::kernel::GemmUniversal<
     cute::Shape<int, int, int, int>,
     typename Config::CollectiveMainloop,
     typename Config::CollectiveEpilogue>;
 
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = gemm::device::GemmUniversalAdapter<GemmKernel>;
 };
 
 TEST(XE_Device_Gemm_s8t_s8t_s32t_tensor_op_s32, 256x256x32) {
-  using LayoutA = cutlass::layout::RowMajor;
-  using LayoutB = cutlass::layout::RowMajor;
+  using LayoutA = layout::RowMajor;
+  using LayoutB = layout::RowMajor;
   using Gemm = XE_Device_Gemm_s8_s8_s32_tensor_op_s32<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
 /*  TODO(Codeplay): Transposed copy are not implemented
 TEST(XE_Device_Gemm_s8n_s8t_s32t_tensor_op_s32, 64x128x32) {
-  using LayoutA = cutlass::layout::ColumnMajor;
-  using LayoutB = cutlass::layout::RowMajor;
+  using LayoutA = layout::ColumnMajor;
+  using LayoutB = layout::RowMajor;
   using Gemm = XE_Device_Gemm_s8_s8_s32_tensor_op_s32<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
 TEST(XE_Device_Gemm_s8t_s8n_s32t_tensor_op_s32, 64x128x32) {
-  using LayoutA = cutlass::layout::RowMajor;
-  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutA = layout::RowMajor;
+  using LayoutB = layout::ColumnMajor;
   using Gemm = XE_Device_Gemm_s8_s8_s32_tensor_op_s32<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
 TEST(XE_Device_Gemm_s8n_s8n_s32t_tensor_op_s32, 64x128x32) {
-  using LayoutA = cutlass::layout::ColumnMajor;
-  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutA = layout::ColumnMajor;
+  using LayoutB = layout::ColumnMajor;
   using Gemm = XE_Device_Gemm_s8_s8_s32_tensor_op_s32<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }

--- a/test/unit/gemm/device/xe_gemm_s8_s8_s32_tensor_op_s32.cpp
+++ b/test/unit/gemm/device/xe_gemm_s8_s8_s32_tensor_op_s32.cpp
@@ -42,76 +42,51 @@
 
 #include "gemm_testbed_3x.hpp"
 
-TEST(XE_Device_Gemm_s8t_s8t_s32t_tensor_op_s32, 256x256x32) {
+namespace {
+template <typename LayoutA, typename LayoutB>
+struct XE_Device_Gemm_s8_s8_s32_tensor_op_s32 {
   using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
     cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    int8_t, cutlass::layout::RowMajor,
-    int8_t, cutlass::layout::RowMajor,
+    int8_t, LayoutA,
+    int8_t, LayoutB,
     int32_t, cutlass::layout::RowMajor,
     int32_t>;
 
   using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue
-  >;
+    cute::Shape<int, int, int, int>,
+    typename Config::CollectiveMainloop,
+    typename Config::CollectiveEpilogue>;
 
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+};
+}
+
+TEST(XE_Device_Gemm_s8t_s8t_s32t_tensor_op_s32, 256x256x32) {
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::RowMajor;
+  using Gemm = XE_Device_Gemm_s8_s8_s32_tensor_op_s32<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
 /*  TODO(Codeplay): Transposed copy are not implemented
 TEST(XE_Device_Gemm_s8n_s8t_s32t_tensor_op_s32, 64x128x32) {
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    int8_t, cutlass::layout::ColumnMajor,
-    int8_t, cutlass::layout::RowMajor,
-    int32_t, cutlass::layout::RowMajor,
-    int32_t>;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using LayoutA = cutlass::layout::ColumnMajor;
+  using LayoutB = cutlass::layout::RowMajor;
+  using Gemm = XE_Device_Gemm_s8_s8_s32_tensor_op_s32<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
 TEST(XE_Device_Gemm_s8t_s8n_s32t_tensor_op_s32, 64x128x32) {
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    int8_t, cutlass::layout::RowMajor,
-    int8_t, cutlass::layout::ColumnMajor,
-    int32_t, cutlass::layout::RowMajor,
-    int32_t>;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  using Gemm = XE_Device_Gemm_s8_s8_s32_tensor_op_s32<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
 TEST(XE_Device_Gemm_s8n_s8n_s32t_tensor_op_s32, 64x128x32) {
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    int8_t, cutlass::layout::ColumnMajor,
-    int8_t, cutlass::layout::ColumnMajor,
-    int32_t, cutlass::layout::RowMajor,
-    int32_t>;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using LayoutA = cutlass::layout::ColumnMajor;
+  using LayoutB = cutlass::layout::ColumnMajor;
+  using Gemm = XE_Device_Gemm_s8_s8_s32_tensor_op_s32<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 */

--- a/test/unit/gemm/device/xe_gemm_s8_s8_s32_tensor_op_s32_cooperative.cpp
+++ b/test/unit/gemm/device/xe_gemm_s8_s8_s32_tensor_op_s32_cooperative.cpp
@@ -38,6 +38,7 @@
 #include "default_gemm_configuration.hpp"
 
 #include "gemm_testbed_3x.hpp"
+namespace cutlass {
 namespace {
 template <typename LayoutA, typename LayoutB>
 struct XE_Device_Gemm_s8_s8_s32_tensor_op_s32_cooperative {
@@ -70,7 +71,6 @@ struct XE_Device_Gemm_s8_s8_s32_tensor_op_s32_cooperative {
 
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
 };
-}
 
 TEST(XE_Device_Gemm_s8t_s8t_s32t_tensor_op_s32_cooperative, 64x128x32) {
   using LayoutA = cutlass::layout::RowMajor;
@@ -105,3 +105,5 @@ TEST(XE_Device_Gemm_s8n_s8n_s32t_tensor_op_s32_cooperative, 64x128x32) {
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 */
+}
+} // namespace cutlass

--- a/test/unit/gemm/device/xe_gemm_s8_s8_s32_tensor_op_s32_cooperative.cpp
+++ b/test/unit/gemm/device/xe_gemm_s8_s8_s32_tensor_op_s32_cooperative.cpp
@@ -45,36 +45,36 @@ struct XE_Device_Gemm_s8_s8_s32_tensor_op_s32_cooperative {
   using ElementA = int8_t;
   using ElementB = int8_t;
 
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
+  using Config = gemm::device::DefaultGemmConfigurationToCutlass3Types<
+    arch::OpClassTensorOp, arch::IntelPVC,
     ElementA, LayoutA,
     ElementB, LayoutB,
-    int32_t, cutlass::layout::RowMajor,
+    int32_t, layout::RowMajor,
     int32_t>;
 
-  using DispatchPolicy = cutlass::gemm::MainloopIntelPVC<3, cutlass::gemm::KernelPVCCooperative>;
+  using DispatchPolicy = gemm::MainloopIntelPVC<3, gemm::KernelPVCCooperative>;
 
-  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
+  using CollectiveMainloop = gemm::collective::CollectiveMma<
     DispatchPolicy, Config::TileShape,
-    ElementA, cutlass::detail::TagToStrideA_t<LayoutA>,
-    ElementB, cutlass::detail::TagToStrideB_t<LayoutB>,
+    ElementA, detail::TagToStrideA_t<LayoutA>,
+    ElementB, detail::TagToStrideB_t<LayoutB>,
     Config::TiledMma,
     Config::GmemTiledCopyA, void, void, cute::identity,  // A
     Config::GmemTiledCopyB, void, void, cute::identity   // B
   >;
 
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+  using GemmKernel = gemm::kernel::GemmUniversal<
       cute::Shape<int,int,int,int>,
       CollectiveMainloop,
       Config::CollectiveEpilogue,
-      cutlass::gemm::StreamKScheduler>;
+      gemm::StreamKScheduler>;
 
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = gemm::device::GemmUniversalAdapter<GemmKernel>;
 };
 
 TEST(XE_Device_Gemm_s8t_s8t_s32t_tensor_op_s32_cooperative, 64x128x32) {
-  using LayoutA = cutlass::layout::RowMajor;
-  using LayoutB = cutlass::layout::RowMajor;
+  using LayoutA = layout::RowMajor;
+  using LayoutB = layout::RowMajor;
   using Gemm = XE_Device_Gemm_s8_s8_s32_tensor_op_s32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
@@ -82,24 +82,24 @@ TEST(XE_Device_Gemm_s8t_s8t_s32t_tensor_op_s32_cooperative, 64x128x32) {
 
 /* TODO(Codeplay): Transposed copy are not implemented
 TEST(XE_Device_Gemm_s8n_s8t_s32t_tensor_op_s32_cooperative, 64x128x32) {
-  using LayoutA = cutlass::layout::ColumnMajor;
-  using LayoutB = cutlass::layout::RowMajor;
+  using LayoutA = layout::ColumnMajor;
+  using LayoutB = layout::RowMajor;
   using Gemm = XE_Device_Gemm_s8_s8_s32_tensor_op_s32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 TEST(XE_Device_Gemm_s8t_s8n_s32t_tensor_op_s32_cooperative, 64x128x32) {
-  using LayoutA = cutlass::layout::RowMajor;
-  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutA = layout::RowMajor;
+  using LayoutB = layout::ColumnMajor;
   using Gemm = XE_Device_Gemm_s8_s8_s32_tensor_op_s32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 TEST(XE_Device_Gemm_s8n_s8n_s32t_tensor_op_s32_cooperative, 64x128x32) {
-  using LayoutA = cutlass::layout::ColumnMajor;
-  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutA = layout::ColumnMajor;
+  using LayoutB = layout::ColumnMajor;
   using Gemm = XE_Device_Gemm_s8_s8_s32_tensor_op_s32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));

--- a/test/unit/gemm/device/xe_gemm_s8_s8_s32_tensor_op_s32_cooperative.cpp
+++ b/test/unit/gemm/device/xe_gemm_s8_s8_s32_tensor_op_s32_cooperative.cpp
@@ -38,12 +38,11 @@
 #include "default_gemm_configuration.hpp"
 
 #include "gemm_testbed_3x.hpp"
-
-TEST(XE_Device_Gemm_s8t_s8t_s32t_tensor_op_s32_cooperative, 64x128x32) {
+namespace {
+template <typename LayoutA, typename LayoutB>
+struct XE_Device_Gemm_s8_s8_s32_tensor_op_s32_cooperative {
   using ElementA = int8_t;
   using ElementB = int8_t;
-  using LayoutA = cutlass::layout::RowMajor;
-  using LayoutB = cutlass::layout::RowMajor;
 
   using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
     cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
@@ -67,119 +66,41 @@ TEST(XE_Device_Gemm_s8t_s8t_s32t_tensor_op_s32_cooperative, 64x128x32) {
       cute::Shape<int,int,int,int>,
       CollectiveMainloop,
       Config::CollectiveEpilogue,
-      cutlass::gemm::StreamKScheduler
-  >;
+      cutlass::gemm::StreamKScheduler>;
 
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+};
+}
+
+TEST(XE_Device_Gemm_s8t_s8t_s32t_tensor_op_s32_cooperative, 64x128x32) {
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::RowMajor;
+  using Gemm = XE_Device_Gemm_s8_s8_s32_tensor_op_s32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 /* TODO(Codeplay): Transposed copy are not implemented
 TEST(XE_Device_Gemm_s8n_s8t_s32t_tensor_op_s32_cooperative, 64x128x32) {
-  using ElementA = int8_t;
-  using ElementB = int8_t;
   using LayoutA = cutlass::layout::ColumnMajor;
   using LayoutB = cutlass::layout::RowMajor;
-
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    ElementA, LayoutA,
-    ElementB, LayoutB,
-    int32_t, cutlass::layout::RowMajor,
-    int32_t>;
-
-  using DispatchPolicy = cutlass::gemm::MainloopIntelPVC<3, cutlass::gemm::KernelPVCCooperative>;
-
-  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
-    DispatchPolicy, Config::TileShape,
-    ElementA, cutlass::detail::TagToStrideA_t<LayoutA>,
-    ElementB, cutlass::detail::TagToStrideB_t<LayoutB>,
-    Config::TiledMma,
-    Config::GmemTiledCopyA, void, void, cute::identity,  // A
-    Config::GmemTiledCopyB, void, void, cute::identity   // B
-  >;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      CollectiveMainloop,
-      Config::CollectiveEpilogue,
-      cutlass::gemm::StreamKScheduler
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_s8_s8_s32_tensor_op_s32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 TEST(XE_Device_Gemm_s8t_s8n_s32t_tensor_op_s32_cooperative, 64x128x32) {
-  using ElementA = int8_t;
-  using ElementB = int8_t;
   using LayoutA = cutlass::layout::RowMajor;
   using LayoutB = cutlass::layout::ColumnMajor;
-
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    ElementA, LayoutA,
-    ElementB, LayoutB,
-    int32_t, cutlass::layout::RowMajor,
-    int32_t>;
-
-  using DispatchPolicy = cutlass::gemm::MainloopIntelPVC<3, cutlass::gemm::KernelPVCCooperative>;
-
-  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
-    DispatchPolicy, Config::TileShape,
-    ElementA, cutlass::detail::TagToStrideA_t<LayoutA>,
-    ElementB, cutlass::detail::TagToStrideB_t<LayoutB>,
-    Config::TiledMma,
-    Config::GmemTiledCopyA, void, void, cute::identity,  // A
-    Config::GmemTiledCopyB, void, void, cute::identity   // B
-  >;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      CollectiveMainloop,
-      Config::CollectiveEpilogue,
-      cutlass::gemm::StreamKScheduler
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_s8_s8_s32_tensor_op_s32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 TEST(XE_Device_Gemm_s8n_s8n_s32t_tensor_op_s32_cooperative, 64x128x32) {
-  using ElementA = int8_t;
-  using ElementB = int8_t;
   using LayoutA = cutlass::layout::ColumnMajor;
   using LayoutB = cutlass::layout::ColumnMajor;
-
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    ElementA, LayoutA,
-    ElementB, LayoutB,
-    int32_t, cutlass::layout::RowMajor,
-    int32_t>;
-
-  using DispatchPolicy = cutlass::gemm::MainloopIntelPVC<3, cutlass::gemm::KernelPVCCooperative>;
-
-  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
-    DispatchPolicy, Config::TileShape,
-    ElementA, cutlass::detail::TagToStrideA_t<LayoutA>,
-    ElementB, cutlass::detail::TagToStrideB_t<LayoutB>,
-    Config::TiledMma,
-    Config::GmemTiledCopyA, void, void, cute::identity,  // A
-    Config::GmemTiledCopyB, void, void, cute::identity   // B
-  >;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      CollectiveMainloop,
-      Config::CollectiveEpilogue,
-      cutlass::gemm::StreamKScheduler
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_s8_s8_s32_tensor_op_s32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }

--- a/test/unit/gemm/device/xe_gemm_tf32_tf32_fp32_tensor_op_fp32.cpp
+++ b/test/unit/gemm/device/xe_gemm_tf32_tf32_fp32_tensor_op_fp32.cpp
@@ -47,19 +47,19 @@ namespace cutlass {
 namespace {
 template <typename LayoutA, typename LayoutB>
 struct XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32 {
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
+  using Config = gemm::device::DefaultGemmConfigurationToCutlass3Types<
+    arch::OpClassTensorOp, arch::IntelPVC,
     tfloat32_t, LayoutA,
     tfloat32_t, LayoutB,
-    float, cutlass::layout::RowMajor,
+    float, layout::RowMajor,
     float>;
 
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+  using GemmKernel = gemm::kernel::GemmUniversal<
       cute::Shape<int,int,int,int>,
       Config::CollectiveMainloop,
       Config::CollectiveEpilogue>;
 
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = gemm::device::GemmUniversalAdapter<GemmKernel>;
 };
 
 TEST(XE_Device_Gemm_tf32t_tf32t_f32t_tensor_op_f32, 256x256x32) {

--- a/test/unit/gemm/device/xe_gemm_tf32_tf32_fp32_tensor_op_fp32.cpp
+++ b/test/unit/gemm/device/xe_gemm_tf32_tf32_fp32_tensor_op_fp32.cpp
@@ -43,76 +43,51 @@
 #include "gemm_testbed_3x.hpp"
 
 /* TODO(Codeplay): TF32 copy builtins don't work well with GEMM. Needs more investigation
-TEST(XE_Device_Gemm_tf32t_tf32t_f32t_tensor_op_f32, 256x256x32) {
+namespace {
+template <typename LayoutA, typename LayoutB>
+struct XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32 {
   using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
     cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    tfloat32_t, cutlass::layout::RowMajor,
-    tfloat32_t, cutlass::layout::RowMajor,
+    tfloat32_t, LayoutA,
+    tfloat32_t, LayoutB,
     float, cutlass::layout::RowMajor,
     float>;
 
   using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
       cute::Shape<int,int,int,int>,
       Config::CollectiveMainloop,
-      Config::CollectiveEpilogue
-  >;
+      Config::CollectiveEpilogue>;
 
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+};
+}
+
+TEST(XE_Device_Gemm_tf32t_tf32t_f32t_tensor_op_f32, 256x256x32) {
+  using LayoutA = RowMajor;
+  using LayoutB = RowMajor;
+  using Gemm = XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
  TODO(Codeplay): missing copy transpose builtin and prefetch builtin
 TEST(XE_Device_Gemm_tf32n_tf32t_f32t_tensor_op_f32, 256x256x32) {
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    tfloat32_t, cutlass::layout::ColumnMajor,
-    tfloat32_t, cutlass::layout::RowMajor,
-    float, cutlass::layout::RowMajor,
-    float>;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using LayoutA = ColumnMajor;
+  using LayoutB = RowMajor;
+  using Gemm = XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
 TEST(XE_Device_Gemm_tf32t_tf32n_f32t_tensor_op_f32, 256x256x32) {
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    tfloat32_t, cutlass::layout::RowMajor,
-    tfloat32_t, cutlass::layout::ColumnMajor,
-    float, cutlass::layout::RowMajor,
-    float>;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using LayoutA = RowMajor;
+  using LayoutB = ColumnMajor;
+  using Gemm = XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 
 TEST(XE_Device_Gemm_tf32n_tf32n_f32t_tensor_op_f32, 256x256x32) {
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    tfloat32_t, cutlass::layout::ColumnMajor,
-    tfloat32_t, cutlass::layout::ColumnMajor,
-    float, cutlass::layout::RowMajor,
-    float>;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      Config::CollectiveMainloop,
-      Config::CollectiveEpilogue
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using LayoutA = ColumnMajor;
+  using LayoutB = ColumnMajor;
+  using Gemm = XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
 */

--- a/test/unit/gemm/device/xe_gemm_tf32_tf32_fp32_tensor_op_fp32.cpp
+++ b/test/unit/gemm/device/xe_gemm_tf32_tf32_fp32_tensor_op_fp32.cpp
@@ -43,6 +43,7 @@
 #include "gemm_testbed_3x.hpp"
 
 /* TODO(Codeplay): TF32 copy builtins don't work well with GEMM. Needs more investigation
+namespace cutlass {
 namespace {
 template <typename LayoutA, typename LayoutB>
 struct XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32 {
@@ -60,7 +61,6 @@ struct XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32 {
 
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
 };
-}
 
 TEST(XE_Device_Gemm_tf32t_tf32t_f32t_tensor_op_f32, 256x256x32) {
   using LayoutA = RowMajor;
@@ -90,4 +90,6 @@ TEST(XE_Device_Gemm_tf32n_tf32n_f32t_tensor_op_f32, 256x256x32) {
   using Gemm = XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32<LayoutA, LayoutB>::Gemm;
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>());
 }
+}
+} // namespace cutlass
 */

--- a/test/unit/gemm/device/xe_gemm_tf32_tf32_fp32_tensor_op_fp32_cooperative.cpp
+++ b/test/unit/gemm/device/xe_gemm_tf32_tf32_fp32_tensor_op_fp32_cooperative.cpp
@@ -46,37 +46,37 @@ struct XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32_cooperative {
   using ElementA = cute::tfloat32_t;
   using ElementB = cute::tfloat32_t;
 
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
+  using Config = gemm::device::DefaultGemmConfigurationToCutlass3Types<
+    arch::OpClassTensorOp, arch::IntelPVC,
     ElementA, LayoutA,
     ElementB, LayoutB,
-    float, cutlass::layout::RowMajor,
+    float, layout::RowMajor,
     float>;
 
-  using DispatchPolicy = cutlass::gemm::MainloopIntelPVC<3, cutlass::gemm::KernelPVCCooperative>;
+  using DispatchPolicy = gemm::MainloopIntelPVC<3, gemm::KernelPVCCooperative>;
 
-  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
+  using CollectiveMainloop = gemm::collective::CollectiveMma<
     DispatchPolicy, typename Config::TileShape,
-    ElementA, cutlass::detail::TagToStrideA_t<LayoutA>,
-    ElementB, cutlass::detail::TagToStrideB_t<LayoutB>,
+    ElementA, detail::TagToStrideA_t<LayoutA>,
+    ElementB, detail::TagToStrideB_t<LayoutB>,
     typename Config::TiledMma,
     typename Config::GmemTiledCopyA, void, void, cute::identity,  // A
     typename Config::GmemTiledCopyB, void, void, cute::identity   // B
   >;
 
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
+  using GemmKernel = gemm::kernel::GemmUniversal<
       cute::Shape<int,int,int,int>,
       CollectiveMainloop,
       typename Config::CollectiveEpilogue,
-      cutlass::gemm::StreamKScheduler
+      gemm::StreamKScheduler
   >;
 
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = gemm::device::GemmUniversalAdapter<GemmKernel>;
 };
 
 TEST(XE_Device_Gemm_tf32t_tf32t_f32t_tensor_op_f32_cooperative, 256x256x32) {
-  using LayoutA = cutlass::layout::RowMajor;
-  using LayoutB = cutlass::layout::RowMajor;
+  using LayoutA = layout::RowMajor;
+  using LayoutB = layout::RowMajor;
   using Gemm = XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
@@ -84,24 +84,24 @@ TEST(XE_Device_Gemm_tf32t_tf32t_f32t_tensor_op_f32_cooperative, 256x256x32) {
 
 /* TODO(Codeplay): missing copy transpose builtin and prefetch builtin
 TEST(XE_Device_Gemm_tf32n_tf32t_f32t_tensor_op_f32_cooperative, 256x256x32) {
-  using LayoutA = cutlass::layout::ColumnMajor;
-  using LayoutB = cutlass::layout::RowMajor;
+  using LayoutA = layout::ColumnMajor;
+  using LayoutB = layout::RowMajor;
   using Gemm = XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 TEST(XE_Device_Gemm_tf32t_tf32n_f32t_tensor_op_f32_cooperative, 256x256x32) {
-  using LayoutA = cutlass::layout::RowMajor;
-  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutA = layout::RowMajor;
+  using LayoutB = layout::ColumnMajor;
   using Gemm = XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 TEST(XE_Device_Gemm_tf32n_tf32n_f32t_tensor_op_f32_cooperative, 256x256x32) {
-  using LayoutA = cutlass::layout::ColumnMajor;
-  using LayoutB = cutlass::layout::ColumnMajor;
+  using LayoutA = layout::ColumnMajor;
+  using LayoutB = layout::ColumnMajor;
   using Gemm = XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));

--- a/test/unit/gemm/device/xe_gemm_tf32_tf32_fp32_tensor_op_fp32_cooperative.cpp
+++ b/test/unit/gemm/device/xe_gemm_tf32_tf32_fp32_tensor_op_fp32_cooperative.cpp
@@ -39,11 +39,11 @@
 
 #include "gemm_testbed_3x.hpp"
 
-TEST(XE_Device_Gemm_tf32t_tf32t_f32t_tensor_op_f32_cooperative, 256x256x32) {
+namespace {
+template <typename LayoutA, typename LayoutB>
+struct XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32_cooperative {
   using ElementA = cute::tfloat32_t;
   using ElementB = cute::tfloat32_t;
-  using LayoutA = cutlass::layout::RowMajor;
-  using LayoutB = cutlass::layout::RowMajor;
 
   using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
     cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
@@ -55,131 +55,54 @@ TEST(XE_Device_Gemm_tf32t_tf32t_f32t_tensor_op_f32_cooperative, 256x256x32) {
   using DispatchPolicy = cutlass::gemm::MainloopIntelPVC<3, cutlass::gemm::KernelPVCCooperative>;
 
   using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
-    DispatchPolicy, Config::TileShape,
+    DispatchPolicy, typename Config::TileShape,
     ElementA, cutlass::detail::TagToStrideA_t<LayoutA>,
     ElementB, cutlass::detail::TagToStrideB_t<LayoutB>,
-    Config::TiledMma,
-    Config::GmemTiledCopyA, void, void, cute::identity,  // A
-    Config::GmemTiledCopyB, void, void, cute::identity   // B
+    typename Config::TiledMma,
+    typename Config::GmemTiledCopyA, void, void, cute::identity,  // A
+    typename Config::GmemTiledCopyB, void, void, cute::identity   // B
   >;
 
   using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
       cute::Shape<int,int,int,int>,
       CollectiveMainloop,
-      Config::CollectiveEpilogue,
+      typename Config::CollectiveEpilogue,
       cutlass::gemm::StreamKScheduler
   >;
 
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+};
+}
+
+TEST(XE_Device_Gemm_tf32t_tf32t_f32t_tensor_op_f32_cooperative, 256x256x32) {
+  using LayoutA = cutlass::layout::RowMajor;
+  using LayoutB = cutlass::layout::RowMajor;
+  using Gemm = XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 /* TODO(Codeplay): missing copy transpose builtin and prefetch builtin
 TEST(XE_Device_Gemm_tf32n_tf32t_f32t_tensor_op_f32_cooperative, 256x256x32) {
-  using ElementA = cute::tfloat32_t;
-  using ElementB = cute::tfloat32_t;
   using LayoutA = cutlass::layout::ColumnMajor;
   using LayoutB = cutlass::layout::RowMajor;
-
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    ElementA, LayoutA,
-    ElementB, LayoutB,
-    float, cutlass::layout::RowMajor,
-    float>;
-
-  using DispatchPolicy = cutlass::gemm::MainloopIntelPVC<3, cutlass::gemm::KernelPVCCooperative>;
-
-  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
-    DispatchPolicy, Config::TileShape,
-    ElementA, cutlass::detail::TagToStrideA_t<LayoutA>,
-    ElementB, cutlass::detail::TagToStrideB_t<LayoutB>,
-    Config::TiledMma,
-    Config::GmemTiledCopyA, void, void, cute::identity,  // A
-    Config::GmemTiledCopyB, void, void, cute::identity   // B
-  >;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      CollectiveMainloop,
-      Config::CollectiveEpilogue,
-      cutlass::gemm::StreamKScheduler
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 TEST(XE_Device_Gemm_tf32t_tf32n_f32t_tensor_op_f32_cooperative, 256x256x32) {
-  using ElementA = cute::tfloat32_t;
-  using ElementB = cute::tfloat32_t;
   using LayoutA = cutlass::layout::RowMajor;
   using LayoutB = cutlass::layout::ColumnMajor;
-
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    ElementA, LayoutA,
-    ElementB, LayoutB,
-    float, cutlass::layout::RowMajor,
-    float>;
-
-  using DispatchPolicy = cutlass::gemm::MainloopIntelPVC<3, cutlass::gemm::KernelPVCCooperative>;
-
-  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
-    DispatchPolicy, Config::TileShape,
-    ElementA, cutlass::detail::TagToStrideA_t<LayoutA>,
-    ElementB, cutlass::detail::TagToStrideB_t<LayoutB>,
-    Config::TiledMma,
-    Config::GmemTiledCopyA, void, void, cute::identity,  // A
-    Config::GmemTiledCopyB, void, void, cute::identity   // B
-  >;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      CollectiveMainloop,
-      Config::CollectiveEpilogue,
-      cutlass::gemm::StreamKScheduler
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 
 TEST(XE_Device_Gemm_tf32n_tf32n_f32t_tensor_op_f32_cooperative, 256x256x32) {
-  using ElementA = cute::tfloat32_t;
-  using ElementB = cute::tfloat32_t;
   using LayoutA = cutlass::layout::ColumnMajor;
   using LayoutB = cutlass::layout::ColumnMajor;
-
-  using Config = cutlass::gemm::device::DefaultGemmConfigurationToCutlass3Types<
-    cutlass::arch::OpClassTensorOp, cutlass::arch::IntelPVC,
-    ElementA, LayoutA,
-    ElementB, LayoutB,
-    float, cutlass::layout::RowMajor,
-    float>;
-
-  using DispatchPolicy = cutlass::gemm::MainloopIntelPVC<3, cutlass::gemm::KernelPVCCooperative>;
-
-  using CollectiveMainloop = cutlass::gemm::collective::CollectiveMma<
-    DispatchPolicy, Config::TileShape,
-    ElementA, cutlass::detail::TagToStrideA_t<LayoutA>,
-    ElementB, cutlass::detail::TagToStrideB_t<LayoutB>,
-    Config::TiledMma,
-    Config::GmemTiledCopyA, void, void, cute::identity,  // A
-    Config::GmemTiledCopyB, void, void, cute::identity   // B
-  >;
-
-  using GemmKernel = cutlass::gemm::kernel::GemmUniversal<
-      cute::Shape<int,int,int,int>,
-      CollectiveMainloop,
-      Config::CollectiveEpilogue,
-      cutlass::gemm::StreamKScheduler
-  >;
-
-  using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
+  using Gemm = XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32_cooperative<LayoutA, LayoutB>::Gemm;
   // TODO(Codeplay): Enable batch tests
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }

--- a/test/unit/gemm/device/xe_gemm_tf32_tf32_fp32_tensor_op_fp32_cooperative.cpp
+++ b/test/unit/gemm/device/xe_gemm_tf32_tf32_fp32_tensor_op_fp32_cooperative.cpp
@@ -39,6 +39,7 @@
 
 #include "gemm_testbed_3x.hpp"
 
+namespace cutlass {
 namespace {
 template <typename LayoutA, typename LayoutB>
 struct XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32_cooperative {
@@ -72,7 +73,6 @@ struct XE_Device_Gemm_tf32_tf32_f32_tensor_op_f32_cooperative {
 
   using Gemm = cutlass::gemm::device::GemmUniversalAdapter<GemmKernel>;
 };
-}
 
 TEST(XE_Device_Gemm_tf32t_tf32t_f32t_tensor_op_f32_cooperative, 256x256x32) {
   using LayoutA = cutlass::layout::RowMajor;
@@ -107,3 +107,5 @@ TEST(XE_Device_Gemm_tf32n_tf32n_f32t_tensor_op_f32_cooperative, 256x256x32) {
   EXPECT_TRUE(test::gemm::device::TestXe<Gemm>(1.0, 0.0, false));
 }
 */
+}
+} // namespace cutlass


### PR DESCRIPTION
A lot of the tests actually have most of the same configuration with just the layout of A and B changed, so I made that more clear by merging the configuration into a template with parameter `LayoutA` and `LayoutB`.