### PR TITLE
Add dummy template parameter to some gpu_generics

### DIFF
--- a/include/cutlass/gpu_generics.h
+++ b/include/cutlass/gpu_generics.h
@@ -387,8 +387,11 @@ enum cudaMemcpyKind {
   cudaMemcpyDeviceToDevice = 3
 };
 
+template <typename T = void>
 CUTLASS_HOST_DEVICE
 cudaError_t cudaMemsetAsync(void *devPtr, unsigned int value, size_t count, cudaStream_t stream = nullptr) {
+  static_assert(std::is_same_v<T, void>, "cudaMemsetAsync takes a dummy template parameter, T = "
+                                         "void, to delay SYCL kernel instantiation");
   syclcompat::fill_async(devPtr, value, count);
   return cudaSuccess;
 }
@@ -397,22 +400,31 @@ using CUresult = unsigned int;
 using CUdeviceptr = unsigned int*;
 constexpr CUresult CUDA_SUCCESS = 0;
 
+template <typename T = void>
 CUTLASS_HOST_DEVICE
 CUresult cuMemsetD32Async(CUdeviceptr devPtr, uint32_t value, size_t count, cudaStream_t stream = nullptr) {
+  static_assert(std::is_same_v<T, void>, "cuMemsetD32Async takes a dummy template parameter, T = "
+                                         "void, to delay SYCL kernel instantiation");
   void *ptr = reinterpret_cast<void *>(devPtr);
   syclcompat::fill_async(ptr, value, count);
   return cudaSuccess;
 }
 
+template <typename T = void>
 CUTLASS_HOST_DEVICE
 CUresult cuMemsetD16Async(CUdeviceptr devPtr, uint16_t value, size_t count, cudaStream_t stream = nullptr) {
+  static_assert(std::is_same_v<T, void>, "cuMemsetD16Async takes a dummy template parameter, T = "
+                                         "void, to delay SYCL kernel instantiation");
   void *ptr = reinterpret_cast<void *>(devPtr);
   syclcompat::fill_async(ptr, value, count);
   return cudaSuccess;
 }
 
+template <typename T = void>
 CUTLASS_HOST_DEVICE
 CUresult cuMemsetD8Async(CUdeviceptr devPtr, uint8_t value, size_t count, cudaStream_t stream = nullptr) {
+  static_assert(std::is_same_v<T, void>, "cuMemsetD8Async takes a dummy template parameter, T = "
+                                         "void, to delay SYCL kernel instantiation");
   void *ptr = reinterpret_cast<void *>(devPtr);
   syclcompat::fill_async(ptr, value, count);
   return cudaSuccess;


### PR DESCRIPTION
This prevents sycl::handler::fill kernels being compiled & included in binaries when not used.