### PR TITLE
Cleanup GEMM pipeline(s) code

### DIFF
--- a/examples/sycl/pvc/CMakeLists.txt
+++ b/examples/sycl/pvc/CMakeLists.txt
@@ -107,4 +107,6 @@ cutlass_example_add_executable(
 cutlass_example_add_executable(
   pvc_gemm_w8a8
   pvc_gemm_w8a8.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_BATCHES
 )

--- a/include/cutlass/epilogue/collective/xe_array_epilogue.hpp
+++ b/include/cutlass/epilogue/collective/xe_array_epilogue.hpp
@@ -201,18 +201,14 @@ public:
     if constexpr (is_source_supported) {
       ElementC const* ptr_C_first_batch = reinterpret_cast<ElementC const*>(args.ptr_C);
       TensorC mC_mnl = make_tensor(make_gmem_ptr(ptr_C_first_batch), make_layout(make_shape(M, N, L), InternalStrideC{}));
-      xe_load_c = make_tiled_copy(Copy_Atom<Trait_C, ElementC>{}.with(mC_mnl),
-                                  Layout<CopyThreadShape>{},
-                                  make_layout(shape_div(typename Trait_C::BlockShape{}, CopyThreadShape{})));
+      xe_load_c = {xe_load_c.with(mC_mnl)};
     }
 
     XE_Copy_D xe_store_d = {};
     if constexpr (is_destination_supported) {
       ElementD* ptr_D_first_batch = reinterpret_cast<ElementD*>(args.ptr_D);
       TensorD mD_mnl = make_tensor(make_gmem_ptr(ptr_D_first_batch), make_layout(make_shape(M, N, L), InternalStrideD{}));
-      xe_store_d = make_tiled_copy(Copy_Atom<Trait_D, ElementD>{}.with(mD_mnl),
-                                   Layout<CopyThreadShape>{},
-                                   make_layout(shape_div(typename Trait_D::BlockShape{}, CopyThreadShape{})));
+      xe_store_d = {xe_store_d.with(mD_mnl)};
     }
 
     return {
@@ -273,11 +269,9 @@ public:
       Accumulator accumulators, 
       TiledMma tiled_mma,
       int thread_idx,
-      char* smem,
       LoadStoreTensor const& load_store_tensors) {
     
     (void) tiled_mma;
-    (void) smem;
     using namespace cute;
 
     static_assert(cute::rank(CtaTileMNK{}) == 3, "CtaTileMNK must be rank-3: [CTA_M, CTA_N, CTA_K]");

--- a/include/cutlass/epilogue/collective/xe_epilogue.hpp
+++ b/include/cutlass/epilogue/collective/xe_epilogue.hpp
@@ -239,8 +239,7 @@ public:
     class TileShapeMNK,
     class TileCoordMNKL,
     class Accumulator,
-    class TiledMma,
-    class ResidueMNK
+    class TiledMma
   >
   CUTLASS_DEVICE void
   operator() (
@@ -249,13 +248,9 @@ public:
       TileCoordMNKL tile_coord_mnkl,
       Accumulator accumulators, 
       TiledMma tiled_mma,
-      ResidueMNK residue_mnk,
-      int thread_idx,
-      char* smem) {
-    
+      int thread_idx) {
+
     (void) tiled_mma;
-    (void) residue_mnk;
-    (void) smem;
     using namespace cute;
 
     static_assert(cute::rank(CtaTileMNK{}) == 3, "CtaTileMNK must be rank-3: [CTA_M, CTA_N, CTA_K]");

--- a/include/cutlass/gemm/collective/xe_mma_mixed_input.hpp
+++ b/include/cutlass/gemm/collective/xe_mma_mixed_input.hpp
@@ -239,9 +239,7 @@ struct CollectiveMma<
     class TensorA,
     class TensorB,
     class FrgTensorC,
-    class KTileIterator,
-    class ResidueMNK,
-    class BlkCoord
+    class KTileIterator
   >
   CUTLASS_DEVICE void
   operator() (
@@ -250,19 +248,12 @@ struct CollectiveMma<
       TensorB gB,
       FrgTensorC const &src_accum,
       KTileIterator k_tile_iter, int k_tile_count,
-      ResidueMNK residue_mnk,
-      BlkCoord const &blk_coord,
       int const &K_start,
       int thread_idx,
-      char *smem_buf,
       Params const& mainloop) 
   {
     static_assert(is_rmem<FrgTensorD>::value, "D tensor must be rmem resident.");
     static_assert(is_rmem<FrgTensorC>::value, "C tensor must be rmem resident.");
-
-    (void)residue_mnk;
-    (void)thread_idx;
-    (void)smem_buf;
 
     // Partition the copying of A and B tiles across the threads
     auto thr_copy_A = mainloop.tiled_copy_a.get_slice(thread_idx);

--- a/include/cutlass/gemm/kernel/xe_gemm_array_cooperative.hpp
+++ b/include/cutlass/gemm/kernel/xe_gemm_array_cooperative.hpp
@@ -291,7 +291,6 @@ public:
         tile_coord,
         K,
         thread_idx,
-        smem_buf,
         params.mainloop,
         AB_tensors
       );
@@ -314,7 +313,6 @@ public:
           accumulators,
           tiled_mma,
           thread_idx,
-          smem_buf,
           CD_tensors
         );
       }

--- a/include/cutlass/gemm/kernel/xe_gemm_cooperative.hpp
+++ b/include/cutlass/gemm/kernel/xe_gemm_cooperative.hpp
@@ -265,13 +265,6 @@ public:
       const int work_k_tile_start = TileScheduler::get_work_k_tile_start(work_tile_info);
       auto k_tile_iter = cute::make_coord_iterator(idx2crd(work_k_tile_start, make_shape(K)), make_shape(K));
 
-      auto k_residue = K - get<2>(subgroup_shape) * (K / get<2>(subgroup_shape));        // K - SUB_K * k_coord_max
-
-      // Compute tile residues for predication
-      auto m_max_coord = M - get<0>(subgroup_shape) * m_coord;                             // M - SUB_M * m_coord
-      auto n_max_coord = N - get<1>(subgroup_shape) * n_coord;                             // N - SUB_N * n_coord
-      auto residue_mnk = make_tuple(m_max_coord, n_max_coord, k_residue);
-
       TiledMma tiled_mma;
       Tensor accumulators = partition_fragment_C(tiled_mma, take<0,2>(workgroup_shape)); 
 
@@ -284,11 +277,8 @@ public:
         gB,
         accumulators,
         k_tile_iter, work_k_tile_count,
-        residue_mnk,
-        tile_coord,
         K,
         thread_idx,
-        smem_buf,
         params.mainloop
       );
 
@@ -305,9 +295,7 @@ public:
           tile_coord,
           accumulators,
           tiled_mma,
-          residue_mnk,
-          thread_idx,
-          smem_buf
+          thread_idx
         );
       }
 


### PR DESCRIPTION
* Remove unused arguments from `mma` and `epilogue`.
* Fix prefetch start idx for streamk/splitk.