### PR TITLE
Make IGC flag specific for mixed precision example

### DIFF
--- a/cmake/FindDPCPP.cmake
+++ b/cmake/FindDPCPP.cmake
@@ -104,9 +104,6 @@ function(add_sycl_to_target)
   if (NOT target_type STREQUAL "OBJECT_LIBRARY")
     target_link_options(${CUTLASS_ADD_SYCL_TARGET} PUBLIC ${DPCPP_FLAGS})
   endif()
-  # TODO(codeplay): Remove these once IGC block load loop hoisting bug is fixed
-  set_target_properties( ${CUTLASS_ADD_SYCL_TARGET} PROPERTIES CXX_COMPILER_LAUNCHER "IGC_allowDecompose2DBlockFuncs=0" )
-  set_target_properties( ${CUTLASS_ADD_SYCL_TARGET} PROPERTIES CXX_LINKER_LAUNCHER "IGC_allowDecompose2DBlockFuncs=0" )
 endfunction()
 
 function(add_sycl_include_directories_to_target NAME)

--- a/examples/sycl/02_pvc_gemm_mixed_dtype/CMakeLists.txt
+++ b/examples/sycl/02_pvc_gemm_mixed_dtype/CMakeLists.txt
@@ -40,3 +40,6 @@ cutlass_example_add_executable(
   TEST_MODE_0
   TEST_A_NARROW
 )
+  # TODO(codeplay): Remove these once IGC block load loop hoisting bug is fixed
+  set_target_properties( 02_pvc_gemm_mixed_dtype PROPERTIES CXX_COMPILER_LAUNCHER "IGC_allowDecompose2DBlockFuncs=0" )
+  set_target_properties( 02_pvc_gemm_mixed_dtype PROPERTIES CXX_LINKER_LAUNCHER "IGC_allowDecompose2DBlockFuncs=0" )


### PR DESCRIPTION
Avoid setting `IGC_allowDecompose2DBlockFuncs=0` for code which doesn't need it.