### PR TITLE
Set flag IGC_VectorAliasBBThreshold=10000 for streamk & grouped_gemm

### DIFF
--- a/examples/sycl/03_pvc_gemm_streamk/CMakeLists.txt
+++ b/examples/sycl/03_pvc_gemm_streamk/CMakeLists.txt
@@ -34,3 +34,6 @@ cutlass_example_add_executable(
   TEST_COMMAND_OPTIONS
   TEST_BATCHES
 )
+# TODO(codeplay): Remove these once IGC VectorAliasThreshold issue is fixed
+set_target_properties( 03_pvc_gemm_streamk PROPERTIES CXX_COMPILER_LAUNCHER "IGC_VectorAliasBBThreshold=10000" )
+set_target_properties( 03_pvc_gemm_streamk PROPERTIES CXX_LINKER_LAUNCHER "IGC_VectorAliasBBThreshold=10000" )

--- a/examples/sycl/04_pvc_grouped_gemm/CMakeLists.txt
+++ b/examples/sycl/04_pvc_grouped_gemm/CMakeLists.txt
@@ -34,3 +34,6 @@ cutlass_example_add_executable(
   TEST_COMMAND_OPTIONS
   TEST_BATCHES
 )
+# TODO(codeplay): Remove these once IGC VectorAliasThreshold issue is fixed
+set_target_properties( 04_pvc_grouped_gemm PROPERTIES CXX_COMPILER_LAUNCHER "IGC_VectorAliasBBThreshold=10000" )
+set_target_properties( 04_pvc_grouped_gemm PROPERTIES CXX_LINKER_LAUNCHER "IGC_VectorAliasBBThreshold=10000" )


### PR DESCRIPTION
Set IGC envar to avoid register spills for streamk & grouped_gemm examples.