### PR TITLE
Fix verification for collective builder example

### DIFF
--- a/examples/sycl/01_pvc_gemm_with_collective_builder/01_pvc_gemm_with_collective_builder.cpp
+++ b/examples/sycl/01_pvc_gemm_with_collective_builder/01_pvc_gemm_with_collective_builder.cpp
@@ -186,8 +186,10 @@ struct ExampleRunner {
     syclcompat::wait();
 
     using TensorView = cutlass::TensorView<ElementOutput, LayoutD>;
-    cutlass::reference::device::TensorReLu(TensorView(block_ref_D.get(), LayoutD::packed({M, N}),
-                                                      cutlass::make_Coord(M, N)));
+    for (int batch = 0, offset = 0; batch < L; batch++, offset += M * N) {
+      cutlass::reference::device::TensorReLu(TensorView(
+          block_ref_D.get() + offset, LayoutD::packed({M, N}), cutlass::make_Coord(M, N)));
+    }
 
     syclcompat::wait();
 

--- a/examples/sycl/01_pvc_gemm_with_collective_builder/CMakeLists.txt
+++ b/examples/sycl/01_pvc_gemm_with_collective_builder/CMakeLists.txt
@@ -28,8 +28,9 @@
 
 set(TEST_BATCHES --l=2)
 
-#TODO: enable batch > 1 test once implementation is fixed.
 cutlass_example_add_executable(
   01_pvc_gemm_with_collective_builder
   01_pvc_gemm_with_collective_builder.cpp
+  TEST_COMMAND_OPTIONS
+  TEST_BATCHES
 )


### PR DESCRIPTION
Re-enable testing batches on pvc collective builder example & fix the verification.